### PR TITLE
feat: email address on users

### DIFF
--- a/src/components/UserForm.vue
+++ b/src/components/UserForm.vue
@@ -10,6 +10,10 @@
       <input v-model="form.name" class="input" required placeholder="z.B. Anna Berger" />
     </div>
     <div>
+      <label class="label">E-Mail</label>
+      <input v-model="form.email" type="email" class="input" placeholder="z.B. anna.berger@schule.ch" />
+    </div>
+    <div>
       <label class="label">{{ user ? 'Neues Passwort (leer = unverändert)' : 'Passwort *' }}</label>
       <input v-model="form.password" type="password" class="input" :required="!user" autocomplete="new-password" />
     </div>
@@ -28,11 +32,11 @@ import { ref, watch } from 'vue'
 const props = defineProps({ user: Object, loading: Boolean })
 const emit  = defineEmits(['submit', 'cancel'])
 
-const form = ref({ username: '', name: '', password: '' })
+const form = ref({ username: '', name: '', email: '', password: '' })
 
 watch(() => props.user, (u) => {
   if (!u) return
-  form.value = { username: u.username, name: u.name, password: '' }
+  form.value = { username: u.username, name: u.name, email: u.email ?? '', password: '' }
 }, { immediate: true })
 
 function submit() { emit('submit', { ...form.value }) }

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -29,7 +29,7 @@
 
         <div class="flex-1 min-w-0">
           <p class="font-semibold text-hi">{{ u.name }}</p>
-          <p class="text-xs text-lo mt-0.5">{{ u.username }}</p>
+          <p class="text-xs text-lo mt-0.5">{{ u.email || u.username }}</p>
           <button v-if="u.avatar" @click.stop="removeAvatar(u)"
                   class="text-xs text-red-500 hover:underline mt-0.5">
             Foto entfernen


### PR DESCRIPTION
## Summary
- `UserForm`: new optional email input field (`type=email`)
- `LearnersView`: shows email below name, falls back to username if not set

## Test plan
- [ ] Open Lernende page — existing users show username as fallback
- [ ] Create new lernender with email — email appears in list
- [ ] Edit lernender — email field pre-filled and editable
- [ ] Clear email on edit — list falls back to username

🤖 Generated with [Claude Code](https://claude.com/claude-code)