### PR TITLE
feat: Passwort-Reset per E-Mail

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -20,6 +20,9 @@ async function req(path, options = {}) {
 
 export const api = {
   login: (body)                  => req('/auth/login', { method: 'POST', body: JSON.stringify(body) }),
+  forgotPassword: (body)         => req('/auth/forgot-password', { method: 'POST', body: JSON.stringify(body) }),
+  resetPassword: (body)          => req('/auth/reset-password', { method: 'POST', body: JSON.stringify(body) }),
+  sendResetEmail: (id)           => req(`/users/${id}/send-reset-email`, { method: 'POST' }),
   getUsers: ()                   => req('/users'),
   getUser: (id)                  => req(`/users/${id}`),
   createUser: (body)             => req('/users', { method: 'POST', body: JSON.stringify(body) }),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,7 +2,8 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 
 const routes = [
-  { path: '/login',        name: 'login',    component: () => import('../views/LoginView.vue'),       meta: { public: true } },
+  { path: '/login',          name: 'login',          component: () => import('../views/LoginView.vue'),         meta: { public: true } },
+  { path: '/passwort-reset', name: 'password-reset', component: () => import('../views/PasswordResetView.vue'), meta: { public: true } },
   { path: '/',             name: 'dashboard',component: () => import('../views/DashboardView.vue') },
   { path: '/projekte',     name: 'projects', component: () => import('../views/ProjectsView.vue') },
   { path: '/projekte/:id', name: 'project',  component: () => import('../views/ProjectDetailView.vue') },

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -12,30 +12,35 @@
 
     <div v-if="users.loading" class="text-center py-12 text-lo italic">Laden…</div>
     <div v-else class="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
-      <div v-for="u in learners" :key="u.id" class="card flex items-center gap-4">
+      <div v-for="u in learners" :key="u.id" class="card flex flex-col gap-3">
 
-        <!-- Avatar with upload overlay -->
-        <div class="relative shrink-0 group cursor-pointer" @click="triggerUpload(u)">
-          <UserAvatar :userId="u.id" :name="u.name" :hasAvatar="u.avatar" size="lg" />
-          <div class="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100
-                      transition-opacity flex items-center justify-center">
-            <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
+        <!-- Top row: avatar + name/email -->
+        <div class="flex items-center gap-4">
+          <!-- Avatar with upload overlay -->
+          <div class="relative shrink-0 group cursor-pointer" @click="triggerUpload(u)">
+            <UserAvatar :userId="u.id" :name="u.name" :hasAvatar="u.avatar" size="lg" />
+            <div class="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100
+                        transition-opacity flex items-center justify-center">
+              <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+              </svg>
+            </div>
+          </div>
+
+          <div class="flex-1 min-w-0">
+            <p class="font-semibold text-hi">{{ u.name }}</p>
+            <p class="text-xs text-lo mt-0.5">{{ u.email || u.username }}</p>
+            <button v-if="u.avatar" @click.stop="removeAvatar(u)"
+                    class="text-xs text-red-500 hover:underline mt-0.5">
+              Foto entfernen
+            </button>
           </div>
         </div>
 
-        <div class="flex-1 min-w-0">
-          <p class="font-semibold text-hi">{{ u.name }}</p>
-          <p class="text-xs text-lo mt-0.5">{{ u.email || u.username }}</p>
-          <button v-if="u.avatar" @click.stop="removeAvatar(u)"
-                  class="text-xs text-red-500 hover:underline mt-0.5">
-            Foto entfernen
-          </button>
-        </div>
-        <div class="flex gap-1 shrink-0 flex-wrap justify-end">
+        <!-- Bottom row: buttons -->
+        <div class="flex gap-1 flex-wrap">
           <button v-if="u.email" class="btn btn-sm btn-secondary" @click="sendReset(u)"
                   title="Passwort-Reset-E-Mail senden">
             Reset-E-Mail

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -35,7 +35,11 @@
             Foto entfernen
           </button>
         </div>
-        <div class="flex gap-1 shrink-0">
+        <div class="flex gap-1 shrink-0 flex-wrap justify-end">
+          <button v-if="u.email" class="btn btn-sm btn-secondary" @click="sendReset(u)"
+                  title="Passwort-Reset-E-Mail senden">
+            Reset-E-Mail
+          </button>
           <button class="btn btn-sm btn-secondary" @click="openEdit(u)">Bearbeiten</button>
           <button class="btn btn-sm btn-danger" @click="remove(u)">Löschen</button>
         </div>
@@ -112,6 +116,16 @@ async function save(body) {
     else               await users.create(body)
     showModal.value = false
   } finally { saving.value = false }
+}
+
+async function sendReset(u) {
+  if (!confirm(`Passwort-Reset-E-Mail an „${u.name}" (${u.email}) senden?`)) return
+  try {
+    await api.sendResetEmail(u.id)
+    alert(`Reset-E-Mail an ${u.email} gesendet.`)
+  } catch (err) {
+    alert(err.message)
+  }
 }
 
 async function remove(u) {

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -19,8 +19,35 @@
         <button type="submit" class="btn-primary w-full justify-center" :disabled="loading">
           {{ loading ? 'Anmelden…' : 'Anmelden' }}
         </button>
+        <p class="text-center">
+          <button type="button" class="text-sm text-brand-600 hover:underline" @click="showForgot = true">
+            Passwort vergessen?
+          </button>
+        </p>
       </form>
     </div>
+
+    <Modal v-model="showForgot" title="Passwort zurücksetzen">
+      <div v-if="forgotSent" class="text-sm text-green-700 bg-green-50 dark:bg-green-950/40 dark:text-green-400 rounded-lg px-3 py-2">
+        Wenn diese E-Mail-Adresse registriert ist, wurde eine Reset-E-Mail versandt.
+      </div>
+      <form v-else @submit.prevent="requestReset" class="space-y-4">
+        <p class="text-sm text-mid">Gib deine E-Mail-Adresse ein. Du erhältst einen Link zum Zurücksetzen deines Passworts.</p>
+        <div>
+          <label class="label">E-Mail-Adresse</label>
+          <input v-model="forgotEmail" type="email" class="input" required autocomplete="email" />
+        </div>
+        <p v-if="forgotError" class="text-sm text-red-600 bg-red-50 dark:bg-red-950/40 dark:text-red-400 rounded-lg px-3 py-2">
+          {{ forgotError }}
+        </p>
+        <div class="flex gap-2 justify-end">
+          <button type="button" class="btn btn-secondary" @click="showForgot = false">Abbrechen</button>
+          <button type="submit" class="btn-primary" :disabled="forgotLoading">
+            {{ forgotLoading ? 'Senden…' : 'Link senden' }}
+          </button>
+        </div>
+      </form>
+    </Modal>
   </div>
 </template>
 
@@ -28,6 +55,8 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
+import { api } from '../api/index.js'
+import Modal from '../components/Modal.vue'
 
 const auth     = useAuthStore()
 const router   = useRouter()
@@ -35,6 +64,12 @@ const username = ref('')
 const password = ref('')
 const loading  = ref(false)
 const error    = ref(null)
+
+const showForgot   = ref(false)
+const forgotEmail  = ref('')
+const forgotLoading = ref(false)
+const forgotError  = ref(null)
+const forgotSent   = ref(false)
 
 async function login() {
   loading.value = true
@@ -46,6 +81,19 @@ async function login() {
     error.value = e.message
   } finally {
     loading.value = false
+  }
+}
+
+async function requestReset() {
+  forgotLoading.value = true
+  forgotError.value   = null
+  try {
+    await api.forgotPassword({ email: forgotEmail.value })
+    forgotSent.value = true
+  } catch (e) {
+    forgotError.value = e.message
+  } finally {
+    forgotLoading.value = false
   }
 }
 </script>

--- a/src/views/PasswordResetView.vue
+++ b/src/views/PasswordResetView.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="min-h-screen bg-gradient-to-br from-brand-700 to-brand-500 flex items-center justify-center p-4">
+    <div class="w-full max-w-sm bg-surface rounded-2xl shadow-xl p-8">
+      <div class="mb-8 text-center">
+        <h1 class="text-2xl font-bold text-hi">Neues Passwort</h1>
+        <p class="text-mid text-sm mt-1">WebIT Abteilung</p>
+      </div>
+
+      <!-- Invalid / missing token -->
+      <div v-if="!token" class="text-center space-y-4">
+        <p class="text-sm text-red-600 bg-red-50 dark:bg-red-950/40 dark:text-red-400 rounded-lg px-3 py-2">
+          Ungültiger oder fehlender Reset-Link.
+        </p>
+        <router-link to="/login" class="text-sm text-brand-600 hover:underline">Zurück zum Login</router-link>
+      </div>
+
+      <!-- Success -->
+      <div v-else-if="success" class="text-center space-y-4">
+        <p class="text-sm text-green-700 bg-green-50 dark:bg-green-950/40 dark:text-green-400 rounded-lg px-3 py-2">
+          Passwort erfolgreich geändert.
+        </p>
+        <router-link to="/login" class="btn-primary inline-flex justify-center w-full">Zum Login</router-link>
+      </div>
+
+      <!-- Form -->
+      <form v-else @submit.prevent="submit" class="space-y-4">
+        <div>
+          <label class="label">Neues Passwort</label>
+          <input v-model="password" type="password" class="input" required minlength="8"
+                 autocomplete="new-password" placeholder="Mindestens 8 Zeichen" />
+        </div>
+        <div>
+          <label class="label">Passwort bestätigen</label>
+          <input v-model="confirm" type="password" class="input" required autocomplete="new-password" />
+        </div>
+        <p v-if="error" class="text-sm text-red-600 bg-red-50 dark:bg-red-950/40 dark:text-red-400 rounded-lg px-3 py-2">
+          {{ error }}
+        </p>
+        <button type="submit" class="btn-primary w-full justify-center" :disabled="loading">
+          {{ loading ? 'Speichern…' : 'Passwort speichern' }}
+        </button>
+        <p class="text-center">
+          <router-link to="/login" class="text-sm text-brand-600 hover:underline">Zurück zum Login</router-link>
+        </p>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { api } from '../api/index.js'
+
+const route   = useRoute()
+const token   = route.query.token || ''
+const password = ref('')
+const confirm  = ref('')
+const loading  = ref(false)
+const error    = ref(null)
+const success  = ref(false)
+
+async function submit() {
+  error.value = null
+  if (password.value !== confirm.value) {
+    error.value = 'Passwörter stimmen nicht überein'
+    return
+  }
+  loading.value = true
+  try {
+    await api.resetPassword({ token, password: password.value })
+    success.value = true
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+</script>


### PR DESCRIPTION
Closes #5

## Summary
- `LoginView.vue`: «Passwort vergessen?»-Link öffnet Modal mit E-Mail-Eingabe; Bestätigungsmeldung unabhängig vom Ergebnis
- `PasswordResetView.vue`: neue öffentliche Route `/passwort-reset?token=…` mit Passwort-/Bestätigungs-Formular und Weiterleitung zum Login
- `LearnersView.vue`: «Reset-E-Mail»-Button pro Lernenden — nur sichtbar wenn E-Mail hinterlegt, mit Bestätigungsdialog
- `src/api/index.js`: drei neue API-Calls (`forgotPassword`, `resetPassword`, `sendResetEmail`)
- `src/router/index.js`: `/passwort-reset` als öffentliche Route registriert

## Dependencies
Benötigt API-PR sbw-neue-medien/abteilung-webit-api#7

## Test plan
- [ ] «Passwort vergessen?» auf Login-Seite → Modal öffnet sich
- [ ] E-Mail absenden → Bestätigungsmeldung erscheint (auch bei unbekannter E-Mail)
- [ ] `/passwort-reset?token=<gültiger-token>` → Formular, Passwort setzen, Weiterleitung
- [ ] `/passwort-reset` ohne Token → Fehlermeldung + Link zum Login
- [ ] Lernenden ohne E-Mail → kein «Reset-E-Mail»-Button
- [ ] Lernenden mit E-Mail → Button vorhanden, Klick öffnet Bestätigungsdialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)