### PR TITLE
feat: Kanban-Vorlagen für Projekte (#7)

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -40,6 +40,7 @@ export const api = {
     }).then(async r => { const d = await r.json(); if (!r.ok) throw new Error(d.error ?? `HTTP ${r.status}`); return d })
   },
   deleteAvatar: (id)             => req(`/users/${id}/avatar`, { method: 'DELETE' }),
+  getTemplates: ()               => req('/templates'),
   getProjects: ()                => req('/projects'),
   getProject: (id)               => req(`/projects/${id}`),
   createProject: (body)          => req('/projects', { method: 'POST', body: JSON.stringify(body) }),

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -47,6 +47,22 @@
       </div>
     </div>
 
+    <template v-if="!project">
+      <div v-if="templates.length && !form.is_template">
+        <label class="label">Vorlage verwenden</label>
+        <select v-model="form.template_id" class="input">
+          <option :value="null">— Keine Vorlage —</option>
+          <option v-for="t in templates" :key="t.id" :value="t.id">{{ t.name }}</option>
+        </select>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input id="is_template" type="checkbox" v-model="form.is_template"
+               class="rounded border-line text-brand-600" />
+        <label for="is_template" class="text-sm text-hi cursor-pointer select-none">Als Vorlage speichern</label>
+      </div>
+    </template>
+
     <div class="flex gap-2 justify-end pt-2">
       <button type="button" class="btn-secondary" @click="$emit('cancel')">Abbrechen</button>
       <button type="submit" class="btn-primary" :disabled="loading">
@@ -59,12 +75,18 @@
 <script setup>
 import { ref, watch } from 'vue'
 
-const props = defineProps({ project: Object, users: { type: Array, default: () => [] }, loading: Boolean })
-const emit  = defineEmits(['submit', 'cancel'])
+const props = defineProps({
+  project:   Object,
+  users:     { type: Array, default: () => [] },
+  templates: { type: Array, default: () => [] },
+  loading:   Boolean,
+})
+const emit = defineEmits(['submit', 'cancel'])
 
 const form = ref({
   name: '', client: '', description: '', status: 'geplant',
   is_personal: false, owner_id: null, member_ids: [],
+  is_template: false, template_id: null,
 })
 
 watch(() => props.project, (p) => {
@@ -77,17 +99,19 @@ watch(() => props.project, (p) => {
     is_personal: !!p.is_personal,
     owner_id:    p.is_personal ? (p.owner_id ?? null) : null,
     member_ids:  (p.members ?? []).map(m => m.id),
+    is_template: false,
+    template_id: null,
   }
 }, { immediate: true })
 
 function submit() {
   const payload = { ...form.value }
   if (payload.is_personal && payload.owner_id) {
-    // Auto-add the selected lernender as a member
     if (!payload.member_ids.includes(payload.owner_id)) {
       payload.member_ids = [payload.owner_id]
     }
   }
+  if (payload.is_template) payload.template_id = null
   emit('submit', payload)
 }
 </script>

--- a/src/stores/projects.js
+++ b/src/stores/projects.js
@@ -3,10 +3,16 @@ import { ref } from 'vue'
 import { api } from '../api/index.js'
 
 export const useProjectsStore = defineStore('projects', () => {
-  const list    = ref([])
-  const current = ref(null)
-  const loading = ref(false)
-  const error   = ref(null)
+  const list      = ref([])
+  const templates = ref([])
+  const current   = ref(null)
+  const loading   = ref(false)
+  const error     = ref(null)
+
+  async function fetchTemplates() {
+    try { templates.value = await api.getTemplates() }
+    catch (e) { /* leiter-only, ignorieren wenn kein Zugriff */ }
+  }
 
   async function fetchAll() {
     loading.value = true
@@ -41,5 +47,5 @@ export const useProjectsStore = defineStore('projects', () => {
     list.value = list.value.filter(p => p.id !== id)
   }
 
-  return { list, current, loading, error, fetchAll, fetchOne, create, update, remove }
+  return { list, templates, current, loading, error, fetchAll, fetchTemplates, fetchOne, create, update, remove }
 })

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -6,46 +6,86 @@
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
-        Neues Projekt
+        {{ activeTab === 'vorlagen' ? 'Neue Vorlage' : 'Neues Projekt' }}
       </button>
     </div>
 
-    <div class="flex flex-wrap gap-2 mb-5">
-      <button v-for="f in filters" :key="f.value" class="btn btn-sm"
-        :class="activeFilter === f.value ? 'btn-primary' : 'btn-secondary'"
-        @click="activeFilter = f.value">
-        {{ f.label }}
+    <div v-if="auth.isLeiter" class="flex gap-1 mb-5 border-b border-groove">
+      <button
+        v-for="tab in tabs" :key="tab.value"
+        class="px-4 py-2 text-sm font-medium transition-colors"
+        :class="activeTab === tab.value
+          ? 'border-b-2 border-brand-600 text-brand-600 -mb-px'
+          : 'text-lo hover:text-mid'"
+        @click="activeTab = tab.value">
+        {{ tab.label }}
+        <span v-if="tab.value === 'vorlagen' && projects.templates.length"
+              class="ml-1 text-xs bg-brand-subtle text-brand-700 rounded-full px-1.5 py-0.5">
+          {{ projects.templates.length }}
+        </span>
       </button>
     </div>
 
-    <div v-if="projects.loading" class="text-lo italic py-8 text-center">Laden…</div>
-    <div v-else class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      <div v-for="p in filtered" :key="p.id"
-           class="card hover:shadow-md transition-shadow cursor-pointer flex flex-col gap-3"
-           @click="router.push(`/projekte/${p.id}`)">
-        <div class="flex items-start justify-between gap-2">
-          <div>
-            <p class="font-semibold text-hi">{{ p.name }}</p>
-            <p v-if="p.client" class="text-xs text-lo mt-0.5">{{ p.client }}</p>
+    <template v-if="activeTab === 'projekte'">
+      <div class="flex flex-wrap gap-2 mb-5">
+        <button v-for="f in filters" :key="f.value" class="btn btn-sm"
+          :class="activeFilter === f.value ? 'btn-primary' : 'btn-secondary'"
+          @click="activeFilter = f.value">
+          {{ f.label }}
+        </button>
+      </div>
+
+      <div v-if="projects.loading" class="text-lo italic py-8 text-center">Laden…</div>
+      <div v-else class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div v-for="p in filtered" :key="p.id"
+             class="card hover:shadow-md transition-shadow cursor-pointer flex flex-col gap-3"
+             @click="router.push(`/projekte/${p.id}`)">
+          <div class="flex items-start justify-between gap-2">
+            <div>
+              <p class="font-semibold text-hi">{{ p.name }}</p>
+              <p v-if="p.client" class="text-xs text-lo mt-0.5">{{ p.client }}</p>
+            </div>
+            <StatusBadge :status="p.status" />
           </div>
-          <StatusBadge :status="p.status" />
+          <p v-if="p.description" class="text-sm text-mid line-clamp-2">{{ p.description }}</p>
+          <div class="flex items-center justify-between mt-auto pt-2 border-t border-groove">
+            <span class="text-xs text-lo">{{ p.owner_name }}</span>
+            <div v-if="auth.isLeiter" class="flex gap-1" @click.stop>
+              <button class="btn btn-sm btn-secondary" @click="openEdit(p)">Bearbeiten</button>
+              <button class="btn btn-sm btn-danger" @click="confirmDelete(p)">Löschen</button>
+            </div>
+          </div>
         </div>
-        <p v-if="p.description" class="text-sm text-mid line-clamp-2">{{ p.description }}</p>
-        <div class="flex items-center justify-between mt-auto pt-2 border-t border-groove">
-          <span class="text-xs text-lo">{{ p.owner_name }}</span>
-          <div v-if="auth.isLeiter" class="flex gap-1" @click.stop>
-            <button class="btn btn-sm btn-secondary" @click="openEdit(p)">Bearbeiten</button>
-            <button class="btn btn-sm btn-danger" @click="confirmDelete(p)">Löschen</button>
+        <div v-if="!filtered.length" class="col-span-full text-center py-12 text-lo italic">Keine Projekte.</div>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div v-for="t in projects.templates" :key="t.id"
+             class="card hover:shadow-md transition-shadow cursor-pointer flex flex-col gap-3"
+             @click="router.push(`/projekte/${t.id}`)">
+          <div class="flex items-start justify-between gap-2">
+            <p class="font-semibold text-hi">{{ t.name }}</p>
+            <span class="text-xs bg-brand-subtle text-brand-700 rounded-full px-2 py-0.5 shrink-0">Vorlage</span>
           </div>
+          <p v-if="t.description" class="text-sm text-mid line-clamp-2">{{ t.description }}</p>
+          <div class="flex justify-end gap-1 mt-auto pt-2 border-t border-groove" @click.stop>
+            <button class="btn btn-sm btn-secondary" @click="openEdit(t)">Bearbeiten</button>
+            <button class="btn btn-sm btn-danger" @click="confirmDelete(t)">Löschen</button>
+          </div>
+        </div>
+        <div v-if="!projects.templates.length" class="col-span-full text-center py-12 text-lo italic">
+          Noch keine Vorlagen. Erstelle ein Projekt und aktiviere „Als Vorlage speichern".
         </div>
       </div>
-      <div v-if="!filtered.length" class="col-span-full text-center py-12 text-lo italic">Keine Projekte.</div>
-    </div>
+    </template>
 
-    <Modal v-model="showModal" :title="editing ? 'Projekt bearbeiten' : 'Neues Projekt'">
+    <Modal v-model="showModal" :title="modalTitle">
       <ProjectForm
         :project="editing"
         :users="users.list.filter(u => u.role === 'lernender')"
+        :templates="activeTab === 'projekte' ? projects.templates : []"
         :loading="saving"
         @submit="save"
         @cancel="showModal = false"
@@ -73,6 +113,12 @@ const showModal    = ref(false)
 const editing      = ref(null)
 const saving       = ref(false)
 const activeFilter = ref('alle')
+const activeTab    = ref('projekte')
+
+const tabs = [
+  { value: 'projekte', label: 'Projekte' },
+  { value: 'vorlagen', label: 'Vorlagen' },
+]
 
 const filters = [
   { value: 'alle',          label: 'Alle' },
@@ -86,7 +132,18 @@ const filtered = computed(() =>
   activeFilter.value === 'alle' ? projects.list : projects.list.filter(p => p.status === activeFilter.value)
 )
 
-onMounted(() => { projects.fetchAll(); if (auth.isLeiter) users.fetchAll() })
+const modalTitle = computed(() => {
+  if (editing.value) return editing.value.is_template ? 'Vorlage bearbeiten' : 'Projekt bearbeiten'
+  return activeTab.value === 'vorlagen' ? 'Neue Vorlage' : 'Neues Projekt'
+})
+
+onMounted(() => {
+  projects.fetchAll()
+  if (auth.isLeiter) {
+    users.fetchAll()
+    projects.fetchTemplates()
+  }
+})
 
 function openCreate() { editing.value = null; showModal.value = true }
 function openEdit(p)  { editing.value = p;    showModal.value = true }
@@ -94,14 +151,22 @@ function openEdit(p)  { editing.value = p;    showModal.value = true }
 async function save(body) {
   saving.value = true
   try {
-    if (editing.value) await projects.update(editing.value.id, body)
-    else               await projects.create(body)
+    if (editing.value) {
+      await projects.update(editing.value.id, body)
+      if (editing.value.is_template) await projects.fetchTemplates()
+    } else {
+      if (activeTab.value === 'vorlagen') body.is_template = true
+      await projects.create(body)
+      if (body.is_template) await projects.fetchTemplates()
+    }
     showModal.value = false
   } finally { saving.value = false }
 }
 
 async function confirmDelete(p) {
-  if (!confirm(`Projekt „${p.name}" wirklich löschen?`)) return
+  const label = p.is_template ? 'Vorlage' : 'Projekt'
+  if (!confirm(`${label} „${p.name}" wirklich löschen?`)) return
   await projects.remove(p.id)
+  if (p.is_template) await projects.fetchTemplates()
 }
 </script>


### PR DESCRIPTION
## Summary

- Neuer Tab „Vorlagen" in der Projektliste (nur für Leiter sichtbar)
- Projekt-Erstellen-Dialog: Vorlage-Dropdown + „Als Vorlage speichern"-Checkbox
- Templates werden beim Erstellen nicht im normalen Projekt-Tab angezeigt
- Vorlagen-Karten im Vorlagen-Tab mit Badge, Edit- und Löschen-Button

## Test plan

- [ ] Backend-PR (abteilung-webit-api#14) zuerst mergen + Migration anwenden
- [ ] Als Leiter: Tab „Vorlagen" erscheint neben „Projekte"
- [ ] Vorlage erstellen → erscheint nur im Vorlagen-Tab
- [ ] Tasks zur Vorlage im Kanban hinzufügen
- [ ] Neues Projekt → Vorlage im Dropdown wählen → Tasks übernommen
- [ ] Als Lernender/Mentor: kein Vorlagen-Tab sichtbar

Closes #7 (Backend-PR: sbw-neue-medien/abteilung-webit-api#14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)