### PR TITLE
feat: JWT Silent Refresh + Sitzung abgelaufen (#15)

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -13,6 +13,12 @@ async function req(path, options = {}) {
     ...options,
     headers: { ...headers(), ...(options.headers ?? {}) },
   })
+  if (res.status === 401) {
+    localStorage.removeItem('token')
+    localStorage.removeItem('user')
+    window.location.href = '/login?expired=1'
+    return
+  }
   const data = await res.json()
   if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`)
   return data
@@ -20,6 +26,7 @@ async function req(path, options = {}) {
 
 export const api = {
   login: (body)                  => req('/auth/login', { method: 'POST', body: JSON.stringify(body) }),
+  refreshToken: ()               => req('/auth/refresh', { method: 'POST' }),
   forgotPassword: (body)         => req('/auth/forgot-password', { method: 'POST', body: JSON.stringify(body) }),
   resetPassword: (body)          => req('/auth/reset-password', { method: 'POST', body: JSON.stringify(body) }),
   sendResetEmail: (id)           => req(`/users/${id}/send-reset-email`, { method: 'POST' }),

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -2,6 +2,12 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { api } from '../api/index.js'
 
+function tokenExp(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))?.exp ?? 0
+  } catch { return 0 }
+}
+
 export const useAuthStore = defineStore('auth', () => {
   const token = ref(localStorage.getItem('token'))
   const user  = ref(JSON.parse(localStorage.getItem('user') ?? 'null'))
@@ -10,20 +16,46 @@ export const useAuthStore = defineStore('auth', () => {
   const isLeiter   = computed(() => user.value?.role === 'leiter')
   const isMentor   = computed(() => user.value?.role === 'mentor')
 
+  let refreshTimer = null
+
+  function startRefreshInterval() {
+    stopRefreshInterval()
+    refreshTimer = setInterval(async () => {
+      if (!token.value) return
+      const remaining = tokenExp(token.value) - Math.floor(Date.now() / 1000)
+      if (remaining < 1800) {
+        try {
+          const res = await api.refreshToken()
+          token.value = res.token
+          localStorage.setItem('token', res.token)
+        } catch { /* 401 wird von req() behandelt */ }
+      }
+    }, 5 * 60 * 1000)
+  }
+
+  function stopRefreshInterval() {
+    clearInterval(refreshTimer)
+    refreshTimer = null
+  }
+
   async function login(username, password) {
     const data = await api.login({ username, password })
     token.value = data.token
     user.value  = data.user
     localStorage.setItem('token', data.token)
     localStorage.setItem('user', JSON.stringify(data.user))
+    startRefreshInterval()
   }
 
   function logout() {
+    stopRefreshInterval()
     token.value = null
     user.value  = null
     localStorage.removeItem('token')
     localStorage.removeItem('user')
   }
+
+  if (token.value) startRefreshInterval()
 
   return { token, user, isLoggedIn, isLeiter, isMentor, login, logout }
 })

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -15,6 +15,9 @@
           <label class="label">Passwort</label>
           <input v-model="password" type="password" class="input" required autocomplete="current-password" />
         </div>
+        <p v-if="sessionExpired && !error" class="text-sm text-amber-700 bg-amber-50 dark:bg-amber-950/40 dark:text-amber-400 rounded-lg px-3 py-2">
+          Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.
+        </p>
         <p v-if="error" class="text-sm text-red-600 bg-red-50 dark:bg-red-950/40 dark:text-red-400 rounded-lg px-3 py-2">{{ error }}</p>
         <button type="submit" class="btn-primary w-full justify-center" :disabled="loading">
           {{ loading ? 'Anmelden…' : 'Anmelden' }}
@@ -53,13 +56,15 @@
 
 <script setup>
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { api } from '../api/index.js'
 import Modal from '../components/Modal.vue'
 
-const auth     = useAuthStore()
-const router   = useRouter()
+const auth           = useAuthStore()
+const router         = useRouter()
+const route          = useRoute()
+const sessionExpired = route.query.expired === '1'
 const username = ref('')
 const password = ref('')
 const loading  = ref(false)


### PR DESCRIPTION
## Summary

- **401-Handling:** Jeder API-Aufruf der 401 zurückbekommt löscht das Token und leitet auf `/login?expired=1` weiter
- **Silent Refresh:** Auth-Store prüft alle 5 Minuten die Restlaufzeit — unter 30 Minuten wird automatisch `POST /auth/refresh` aufgerufen
- **App-Start:** Interval startet auch wenn ein Token bereits im localStorage liegt (Browser neu öffnen)
- **Login-Seite:** Zeigt einen Hinweis „Deine Sitzung ist abgelaufen" wenn `?expired=1` in der URL ist

## Test plan

- [ ] Backend-PR (abteilung-webit-api#17) zuerst mergen
- [ ] Einloggen → 24h warten → App öffnen → Redirect auf Login mit Meldung
- [ ] Token manuell im localStorage auf abgelaufenes setzen → API-Call → Redirect
- [ ] Normal eingeloggt bleiben → kein Logout nach 24h (silent refresh greift)

Backend-PR: sbw-neue-medien/abteilung-webit-api#17

🤖 Generated with [Claude Code](https://claude.com/claude-code)