### PR TITLE
feat: Markdown-Rendering für Beschreibungsfelder (#13)

### DIFF
--- a/src/components/KanbanCard.vue
+++ b/src/components/KanbanCard.vue
@@ -25,7 +25,7 @@
       </div>
     </div>
 
-    <p v-if="task.description" class="mt-1 text-xs text-mid line-clamp-2">{{ task.description }}</p>
+    <p v-if="task.description" class="mt-1 text-xs text-mid line-clamp-2">{{ markdownPreview(task.description) }}</p>
 
     <!-- Sprint badge -->
     <div v-if="task.sprint_name" class="mt-2">
@@ -69,6 +69,11 @@
 <script setup>
 import { ref, computed } from 'vue'
 import UserAvatar from './UserAvatar.vue'
+import { marked } from 'marked'
+
+function markdownPreview(text) {
+  return marked.parse(text ?? '').replace(/<[^>]*>/g, '')
+}
 
 const props = defineProps({ task: Object, readonly: Boolean })
 defineEmits(['edit', 'delete'])

--- a/src/components/MarkdownRenderer.vue
+++ b/src/components/MarkdownRenderer.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="markdown-content text-sm text-mid" v-html="html" />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { marked } from 'marked'
+
+const props = defineProps({ content: { type: String, default: '' } })
+const html = computed(() => marked.parse(props.content ?? ''))
+</script>
+
+<style scoped>
+.markdown-content :deep(p)           { margin-bottom: 0.5rem; }
+.markdown-content :deep(p:last-child){ margin-bottom: 0; }
+.markdown-content :deep(ul),
+.markdown-content :deep(ol)          { padding-left: 1.25rem; margin-bottom: 0.5rem; }
+.markdown-content :deep(ul)          { list-style: disc; }
+.markdown-content :deep(ol)          { list-style: decimal; }
+.markdown-content :deep(li)          { margin-bottom: 0.125rem; }
+.markdown-content :deep(strong)      { font-weight: 600; }
+.markdown-content :deep(em)          { font-style: italic; }
+.markdown-content :deep(code)        { font-family: monospace; background: rgba(0,0,0,.06); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em; }
+.markdown-content :deep(h1),
+.markdown-content :deep(h2),
+.markdown-content :deep(h3)          { font-weight: 600; margin-bottom: 0.25rem; }
+</style>

--- a/src/components/SprintPanel.vue
+++ b/src/components/SprintPanel.vue
@@ -32,7 +32,7 @@
             <p class="text-xs text-mid mt-1">
               {{ formatDate(sprint.start_date) }} – {{ formatDate(sprint.end_date) }}
             </p>
-            <p v-if="sprint.goal" class="text-sm text-mid mt-1">{{ sprint.goal }}</p>
+            <MarkdownRenderer v-if="sprint.goal" class="mt-1" :content="sprint.goal" />
           </div>
           <div class="flex items-center gap-3 shrink-0">
             <span class="text-xs text-lo">{{ sprint.task_count }} Aufgaben</span>
@@ -108,6 +108,7 @@ import { ref, computed } from 'vue'
 import { useSprintsStore } from '../stores/sprints.js'
 import { useAuthStore } from '../stores/auth.js'
 import Modal from './Modal.vue'
+import MarkdownRenderer from './MarkdownRenderer.vue'
 
 const props = defineProps({ tasks: { type: Array, default: () => [] } })
 

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -33,7 +33,7 @@
           <p class="text-sm font-medium text-hi" :class="{ 'line-through text-lo': todo.done }">
             {{ todo.title }}
           </p>
-          <p v-if="todo.description" class="text-xs text-mid mt-0.5">{{ todo.description }}</p>
+          <MarkdownRenderer v-if="todo.description" class="mt-0.5 text-xs" :content="todo.description" />
           <div class="flex flex-wrap items-center gap-3 mt-1.5">
             <span class="text-xs text-lo">
               <span class="font-medium text-mid">Geplant:</span> {{ formatDuration(todo.planned_duration_min) }}
@@ -100,6 +100,7 @@ import { ref, computed } from 'vue'
 import { useTodosStore } from '../stores/todos.js'
 import { useAuthStore } from '../stores/auth.js'
 import Modal from './Modal.vue'
+import MarkdownRenderer from './MarkdownRenderer.vue'
 
 const todos = useTodosStore()
 const auth  = useAuthStore()

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -10,7 +10,7 @@
             <StatusBadge :status="projects.current.status" />
             <span v-if="projects.current.client" class="text-sm text-lo">{{ projects.current.client }}</span>
           </div>
-          <p v-if="projects.current.description" class="mt-2 text-sm text-mid">{{ projects.current.description }}</p>
+          <MarkdownRenderer v-if="projects.current.description" class="mt-2" :content="projects.current.description" />
         </div>
         <div class="flex gap-2 shrink-0">
           <button v-if="auth.isLeiter" class="btn-secondary" @click="showEdit = true">Bearbeiten</button>
@@ -129,6 +129,7 @@ import StatusBadge from '../components/StatusBadge.vue'
 import Modal from '../components/Modal.vue'
 import ProjectForm from '../components/ProjectForm.vue'
 import TodoList from '../components/TodoList.vue'
+import MarkdownRenderer from '../components/MarkdownRenderer.vue'
 
 const route      = useRoute()
 const auth       = useAuthStore()

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -47,7 +47,7 @@
             </div>
             <StatusBadge :status="p.status" />
           </div>
-          <p v-if="p.description" class="text-sm text-mid line-clamp-2">{{ p.description }}</p>
+          <p v-if="p.description" class="text-sm text-mid line-clamp-2">{{ markdownPreview(p.description) }}</p>
           <div class="flex items-center justify-between mt-auto pt-2 border-t border-groove">
             <span class="text-xs text-lo">{{ p.owner_name }}</span>
             <div v-if="auth.isLeiter" class="flex gap-1" @click.stop>
@@ -69,7 +69,7 @@
             <p class="font-semibold text-hi">{{ t.name }}</p>
             <span class="text-xs bg-brand-subtle text-brand-700 rounded-full px-2 py-0.5 shrink-0">Vorlage</span>
           </div>
-          <p v-if="t.description" class="text-sm text-mid line-clamp-2">{{ t.description }}</p>
+          <p v-if="t.description" class="text-sm text-mid line-clamp-2">{{ markdownPreview(t.description) }}</p>
           <div class="flex justify-end gap-1 mt-auto pt-2 border-t border-groove" @click.stop>
             <button class="btn btn-sm btn-secondary" @click="openEdit(t)">Bearbeiten</button>
             <button class="btn btn-sm btn-danger" @click="confirmDelete(t)">Löschen</button>
@@ -103,6 +103,11 @@ import { useUsersStore } from '../stores/users.js'
 import StatusBadge from '../components/StatusBadge.vue'
 import Modal from '../components/Modal.vue'
 import ProjectForm from '../components/ProjectForm.vue'
+import { marked } from 'marked'
+
+function markdownPreview(text) {
+  return marked.parse(text ?? '').replace(/<[^>]*>/g, '')
+}
 
 const auth     = useAuthStore()
 const projects = useProjectsStore()


### PR DESCRIPTION
## Summary

- Neue `MarkdownRenderer`-Komponente (`marked` war bereits installiert, aber ungenutzt)
- **Vollansicht** rendert Markdown: Projektbeschreibung (Detailseite), Todo-Beschreibung, Sprint-Ziel
- **Kartenvorschau** zeigt Plaintext ohne Markdown-Syntax: Projektliste, Vorlagen-Tab, Kanban-Karte
- Eingabefelder bleiben plain `<textarea>` — kein WYSIWYG, Markdown wird beim Speichern als Text abgelegt

## Test plan

- [ ] Projektbeschreibung mit `**fett**`, `- Liste`, `## Titel` → in Detailansicht gerendert, in der Karte als sauberer Plaintext
- [ ] Aufgabenbeschreibung mit Markdown → Kanban-Karte zeigt Plaintext-Preview
- [ ] Todo-Beschreibung → gerendert in der Liste
- [ ] Sprint-Ziel → gerendert im Sprint-Panel
- [ ] Kein Layout-Bruch bei langen Inhalten

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)