### PR TITLE
refact: Kanban centered, Todos als rechte Sidebar auf breiten Screens

### DIFF
--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex gap-4 overflow-x-auto pb-4 min-h-[60vh]">
     <div v-for="col in columns" :key="col.status"
-      class="flex-shrink-0 w-72 flex flex-col gap-2"
+      class="flex-shrink-0 w-60 flex flex-col gap-2"
       @dragover.prevent
       @dragenter.prevent="onDragEnter(col.status)"
       @dragleave="dragOver = null"

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -44,11 +44,14 @@
         </button>
       </div>
 
-      <KanbanBoard :tasks="filteredTasks" :readonly="auth.isMentor"
-                   @move="moveTask" @add="addTask" @edit="openEditTask" @delete="deleteTask" />
-
-      <div class="mt-8 max-w-7xl mx-auto">
-        <TodoList />
+      <div class="flex flex-col xl:flex-row gap-6 max-w-7xl mx-auto">
+        <div class="flex-1 min-w-0">
+          <KanbanBoard :tasks="filteredTasks" :readonly="auth.isMentor"
+                       @move="moveTask" @add="addTask" @edit="openEditTask" @delete="deleteTask" />
+        </div>
+        <div class="xl:w-80 shrink-0">
+          <TodoList />
+        </div>
       </div>
 
       <div v-if="auth.isLeiter && projects.current.members?.length" class="mt-6 max-w-7xl mx-auto">

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -49,7 +49,7 @@
           <KanbanBoard :tasks="filteredTasks" :readonly="auth.isMentor"
                        @move="moveTask" @add="addTask" @edit="openEditTask" @delete="deleteTask" />
         </div>
-        <div class="xl:w-80 shrink-0">
+        <div class="xl:w-60 shrink-0">
           <TodoList />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Kanban board is now the centered main content, bounded by `max-w-7xl mx-auto`
- On `xl` screens (≥1280px) the TodoList moves to a fixed `w-80` right sidebar
- On smaller screens both sections stack vertically (unchanged behavior)
- KanbanBoard's own `overflow-x-auto` handles horizontal scroll within the flex column

Closes #28
