### PR TITLE
fix: Mentor→Coach, Lernende→Lernpartner in UI-Labels

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -61,7 +61,7 @@ const links = computed(() => {
       { to: '/',              label: 'Dashboard' },
       { to: '/projekte',      label: 'Projekte' },
       { to: '/zeiterfassung', label: 'Zeiterfassung' },
-      { to: '/lernende',      label: 'Lernende' },
+      { to: '/lernende',      label: 'Lernpartner' },
     ]
   }
   const base = [
@@ -71,8 +71,8 @@ const links = computed(() => {
     { to: '/mein-bereich',  label: 'Mein Bereich' },
   ]
   if (auth.isLeiter) base.push({ to: '/sprints', label: 'Sprints' })
-  if (auth.isLeiter) base.push({ to: '/lernende', label: 'Lernende' })
-  if (auth.isLeiter) base.push({ to: '/mentoren', label: 'Mentoren' })
+  if (auth.isLeiter) base.push({ to: '/lernende', label: 'Lernpartner' })
+  if (auth.isLeiter) base.push({ to: '/mentoren', label: 'Coaches' })
   return base
 })
 

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -25,11 +25,11 @@
     <div class="flex items-center gap-2">
       <input id="is_personal" type="checkbox" v-model="form.is_personal"
              class="rounded border-line text-brand-600" />
-      <label for="is_personal" class="text-sm text-hi cursor-pointer select-none">Eigenprojekt (einem Lernenden zuordnen)</label>
+      <label for="is_personal" class="text-sm text-hi cursor-pointer select-none">Eigenprojekt (einem Lernpartner zuordnen)</label>
     </div>
 
     <div v-if="form.is_personal && users.length">
-      <label class="label">Lernender *</label>
+      <label class="label">Lernpartner *</label>
       <select v-model="form.owner_id" class="input" required>
         <option :value="null">— Bitte wählen —</option>
         <option v-for="u in users" :key="u.id" :value="u.id">{{ u.name }}</option>
@@ -37,7 +37,7 @@
     </div>
 
     <div v-if="!form.is_personal && users.length">
-      <label class="label">Lernende zuweisen</label>
+      <label class="label">Lernpartner zuweisen</label>
       <div class="space-y-1 max-h-40 overflow-y-auto border border-line rounded-lg p-2 bg-lift">
         <label v-for="u in users" :key="u.id" class="flex items-center gap-2 text-sm cursor-pointer text-hi">
           <input type="checkbox" :value="u.id" v-model="form.member_ids"

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -14,12 +14,12 @@
 
     <!-- Mentor: assigned learner hours -->
     <section v-if="auth.isMentor && learnerHours.length">
-      <h2 class="text-sm font-semibold text-lo uppercase tracking-wide mb-3">Aufwand meiner Lernenden</h2>
+      <h2 class="text-sm font-semibold text-lo uppercase tracking-wide mb-3">Aufwand meiner Lernpartner</h2>
       <div class="card overflow-hidden p-0">
         <table class="min-w-full text-sm">
           <thead class="bg-lift border-b border-line">
             <tr>
-              <th class="px-4 py-3 text-left font-medium text-mid">Lernende/r</th>
+              <th class="px-4 py-3 text-left font-medium text-mid">Lernpartner</th>
               <th class="px-4 py-3 text-right font-medium text-mid">Stunden total</th>
               <th class="px-4 py-3 text-right font-medium text-mid">Ausstehend</th>
               <th class="px-4 py-3 w-40"></th>
@@ -134,12 +134,12 @@
 
     <!-- Leiter only: hours per learner -->
     <section v-if="auth.isLeiter && learnerHours.length">
-      <h2 class="text-sm font-semibold text-lo uppercase tracking-wide mb-3">Aufwand pro Lernende</h2>
+      <h2 class="text-sm font-semibold text-lo uppercase tracking-wide mb-3">Aufwand pro Lernpartner</h2>
       <div class="card overflow-hidden p-0">
         <table class="min-w-full text-sm">
           <thead class="bg-lift border-b border-line">
             <tr>
-              <th class="px-4 py-3 text-left font-medium text-mid">Lernende/r</th>
+              <th class="px-4 py-3 text-left font-medium text-mid">Lernpartner</th>
               <th class="px-4 py-3 text-right font-medium text-mid">Stunden total</th>
               <th class="px-4 py-3 text-right font-medium text-mid">Ausstehend</th>
               <th class="px-4 py-3 w-40"></th>
@@ -187,7 +187,7 @@
 
     <section>
       <h2 class="text-sm font-semibold text-lo uppercase tracking-wide mb-3">
-        {{ auth.isLeiter ? 'Projektübersicht' : auth.isMentor ? 'Projekte meiner Lernenden' : 'Meine Projekte' }}
+        {{ auth.isLeiter ? 'Projektübersicht' : auth.isMentor ? 'Projekte meiner Lernpartner' : 'Meine Projekte' }}
       </h2>
       <div class="card overflow-hidden p-0">
         <table class="min-w-full text-sm">

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="max-w-6xl mx-auto px-4 py-8 space-y-6">
     <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-hi">Lernende</h1>
+      <h1 class="text-2xl font-bold text-hi">Lernpartner</h1>
       <button v-if="auth.isLeiter" class="btn-primary" @click="openCreate">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
-        Lernenden anlegen
+        Lernpartner anlegen
       </button>
     </div>
 
@@ -53,7 +53,7 @@
         </div>
       </div>
       <div v-if="!learners.length" class="col-span-2 text-center py-12 text-lo italic">
-        Noch keine Lernenden erfasst.
+        Noch keine Lernpartner erfasst.
       </div>
     </div>
 
@@ -61,7 +61,7 @@
     <input ref="fileInput" type="file" accept="image/jpeg,image/png,image/webp"
            class="hidden" @change="onFileSelected" />
 
-    <Modal v-model="showModal" :title="editing ? 'Lernenden bearbeiten' : 'Lernenden anlegen'">
+    <Modal v-model="showModal" :title="editing ? 'Lernpartner bearbeiten' : 'Lernpartner anlegen'">
       <UserForm :user="editing" :loading="saving" @submit="save" @cancel="showModal = false" />
       <p v-if="!editing" class="mt-3 text-xs text-lo">
         Beim Anlegen wird automatisch ein Eigenprojekt erstellt.

--- a/src/views/MentorsView.vue
+++ b/src/views/MentorsView.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="max-w-6xl mx-auto px-4 py-8 space-y-6">
     <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-hi">Mentoren</h1>
+      <h1 class="text-2xl font-bold text-hi">Coaches</h1>
       <button class="btn-primary" @click="openCreate">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
-        Mentor anlegen
+        Coach anlegen
       </button>
     </div>
 
@@ -23,7 +23,7 @@
 
         <!-- Assigned learners -->
         <div>
-          <p class="text-xs font-medium text-lo uppercase tracking-wide mb-1">Zugewiesene Lernende</p>
+          <p class="text-xs font-medium text-lo uppercase tracking-wide mb-1">Zugewiesene Lernpartner</p>
           <div v-if="!assignments[m.id]?.length" class="text-xs text-lo italic">Keine zugewiesen</div>
           <div v-else class="flex flex-wrap gap-1">
             <span v-for="l in assignments[m.id]" :key="l.id"
@@ -37,7 +37,7 @@
         <!-- Assign learner -->
         <div class="flex gap-2 items-center">
           <select v-model="assignTarget[m.id]" class="input flex-1 text-sm py-1">
-            <option value="">Lernenden zuweisen…</option>
+            <option value="">Lernpartner zuweisen…</option>
             <option v-for="l in unassignedFor(m)" :key="l.id" :value="l.id">{{ l.name }}</option>
           </select>
           <button class="btn btn-sm btn-secondary" :disabled="!assignTarget[m.id]"
@@ -55,11 +55,11 @@
       </div>
 
       <div v-if="!mentors.length" class="col-span-3 text-center py-12 text-lo italic">
-        Noch keine Mentoren erfasst.
+        Noch keine Coaches erfasst.
       </div>
     </div>
 
-    <Modal v-model="showModal" :title="editing ? 'Mentor bearbeiten' : 'Mentor anlegen'">
+    <Modal v-model="showModal" :title="editing ? 'Coach bearbeiten' : 'Coach anlegen'">
       <MentorForm :mentor="editing" :loading="saving" @submit="save" @cancel="showModal = false" />
     </Modal>
   </div>
@@ -118,7 +118,7 @@ async function save(body) {
 }
 
 async function remove(m) {
-  if (!confirm(`Mentor „${m.name}" wirklich löschen?`)) return
+  if (!confirm(`Coach „${m.name}" wirklich löschen?`)) return
   await api.deleteMentor(m.id)
   await fetchMentors()
 }

--- a/src/views/MyAreaView.vue
+++ b/src/views/MyAreaView.vue
@@ -6,7 +6,7 @@
       <UserAvatar :userId="auth.user?.id" :name="auth.user?.name" :hasAvatar="auth.user?.avatar" size="lg" class="w-16 h-16 text-2xl" />
       <div class="flex-1">
         <h2 class="text-xl font-semibold text-hi">{{ auth.user?.name }}</h2>
-        <p class="text-sm text-mid">{{ auth.user?.role === 'leiter' ? 'Abteilungsleiter' : 'Lernender' }}</p>
+        <p class="text-sm text-mid">{{ auth.user?.role === 'leiter' ? 'Abteilungsleiter' : auth.user?.role === 'mentor' ? 'Coach' : 'Lernpartner' }}</p>
       </div>
       <button class="btn-secondary" @click="showPwModal = true">Passwort ändern</button>
     </div>

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -36,7 +36,7 @@
         <select v-if="auth.isLeiter && lernende.length"
                 v-model="learnerFilter"
                 class="ml-auto input py-1 text-sm w-auto">
-          <option :value="null">Alle Lernenden</option>
+          <option :value="null">Alle Lernpartner</option>
           <option v-for="u in lernende" :key="u.id" :value="u.id">{{ u.name }}</option>
         </select>
       </div>

--- a/src/views/TimeEntryView.vue
+++ b/src/views/TimeEntryView.vue
@@ -14,7 +14,7 @@
       <div><label class="label">Von</label><input v-model="filter.from" type="date" class="input w-40" /></div>
       <div><label class="label">Bis</label><input v-model="filter.to" type="date" class="input w-40" /></div>
       <div v-if="auth.isLeiter || auth.isMentor">
-        <label class="label">Lernender</label>
+        <label class="label">Lernpartner</label>
         <select v-model="filter.user_id" class="input w-48">
           <option value="">Alle</option>
           <option v-for="u in learners" :key="u.id" :value="u.id">{{ u.name }}</option>


### PR DESCRIPTION
## Summary
- All user-visible labels renamed: **Mentor → Coach**, **Lernende → Lernpartner**
- Code variables, route paths (`/mentoren`, `/lernende`), and API role values (`mentor`, `lernender`) are unchanged — backend-only strings
- Fixed `MyAreaView` which previously showed "Lernender" for the Coach role

## Files changed
- `NavBar.vue` — nav labels
- `MentorsView.vue` — page heading, buttons, modal title, confirm dialog
- `LearnersView.vue` — page heading, buttons, modal title, empty state
- `DashboardView.vue` — section headings, table column header
- `ProjectForm.vue` — labels for personal project assignment
- `ProjectsView.vue` — learner filter dropdown
- `TimeEntryView.vue` — filter label
- `MyAreaView.vue` — role display (also adds Coach case)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)