### PR TITLE
fix: full page reload on logout to clear stale Pinia store

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -45,13 +45,11 @@
 
 <script setup>
 import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useDarkMode } from '../composables/useDarkMode.js'
 import HelpModal from './HelpModal.vue'
 
 const auth     = useAuthStore()
-const router   = useRouter()
 const { isDark, toggle } = useDarkMode()
 const showHelp = ref(false)
 
@@ -78,6 +76,6 @@ const links = computed(() => {
 
 function logout() {
   auth.logout()
-  router.push('/login')
+  window.location.href = '/login'
 }
 </script>


### PR DESCRIPTION
## Problem
A lernender logging in after a leiter session (same browser tab, no page reload) would see all projects instead of only their own. The backend SQL filter is correct — the issue is that Pinia stores survive `router.push` navigation. After logout, `projects.list` still held the leiter's full project list until the lernender's `fetchAll()` completed.

## Fix
Use `window.location.href = '/login'` on logout instead of `router.push('/login')`. A full page reload clears all in-memory Pinia state, consistent with the existing 401-expiry redirect in `api/index.js` which already uses `window.location.href`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)