### PR TITLE
docs: update README to v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Vue 3 Single-Page Application für die Verwaltung der webIT-Abteilung.
 
-**Version:** 1.4.0
+**Version:** 1.5.0
 **Repo:** `sbw-neue-medien/abteilung-webit-dash`
 **Backend:** [`sbw-neue-medien/abteilung-webit-api`](https://github.com/sbw-neue-medien/abteilung-webit-api)
 
@@ -35,13 +35,21 @@ Das Frontend kommuniziert ausschliesslich über HTTP-Requests mit dem Backend (`
 src/
 ├── api/          # Alle HTTP-Calls (api/index.js)
 ├── components/   # Wiederverwendbare Komponenten
+│   ├── Footer.vue
+│   ├── HelpModal.vue
 │   ├── KanbanBoard.vue
 │   ├── KanbanCard.vue
+│   ├── MarkdownRenderer.vue
 │   ├── MentorForm.vue
-│   ├── SprintPanel.vue
-│   ├── TodoList.vue
+│   ├── Modal.vue
+│   ├── NavBar.vue
 │   ├── ProjectForm.vue
-│   └── Modal.vue
+│   ├── SprintPanel.vue
+│   ├── StatusBadge.vue
+│   ├── TimeEntryForm.vue
+│   ├── TodoList.vue
+│   ├── UserAvatar.vue
+│   └── UserForm.vue
 ├── stores/       # Pinia Stores
 │   ├── auth.js
 │   ├── projects.js
@@ -51,14 +59,16 @@ src/
 │   ├── todos.js
 │   └── users.js
 ├── views/        # Seiten-Komponenten (eine pro Route)
-│   ├── LoginView.vue
 │   ├── DashboardView.vue
-│   ├── ProjectsView.vue
-│   ├── ProjectDetailView.vue
-│   ├── TimeEntryView.vue
 │   ├── LearnersView.vue
+│   ├── LoginView.vue
 │   ├── MentorsView.vue
-│   └── MyAreaView.vue
+│   ├── MyAreaView.vue
+│   ├── PasswordResetView.vue
+│   ├── ProjectDetailView.vue
+│   ├── ProjectsView.vue
+│   ├── SprintsView.vue
+│   └── TimeEntryView.vue
 └── router/       # Route-Definitionen
 ```
 
@@ -69,28 +79,35 @@ src/
 | Pfad | Seite | Zugang |
 |---|---|---|
 | `/login` | Login | öffentlich |
+| `/passwort-reset` | Passwort zurücksetzen | öffentlich |
 | `/` | Dashboard | alle |
 | `/projekte` | Projektübersicht | alle |
 | `/projekte/:id` | Projektdetail (Kanban + Sprints + Todos) | alle |
 | `/zeiterfassung` | Zeiterfassung | alle |
-| `/lernende` | Lernende verwalten | Leiter (voll), Mentor (read-only) |
-| `/mentoren` | Mentoren verwalten + Zuweisung | nur Leiter |
-| `/mein-bereich` | Eigenes Profil & Stunden | Leiter, Lernender |
+| `/mein-bereich` | Eigenes Profil & Stunden | Leiter, Lernpartner |
+| `/sprints` | Sprint-Verwaltung | nur Leiter |
+| `/lernende` | Lernpartner verwalten | Leiter (voll), Coach (read-only) |
+| `/mentoren` | Coaches verwalten + Zuweisung | nur Leiter |
 
 ---
 
 ## Features
 
-- **Kanban-Board** mit Drag-and-Drop (Offen → In Arbeit → Review → Erledigt)
+- **Kanban-Board** mit Drag-and-Drop (Offen → In Arbeit → Review → Erledigt), TodoList als rechte Sidebar
 - **Kanban-Vorlagen** — Projekte als Vorlage speichern; Tasks werden beim Erstellen eines neuen Projekts übernommen
-- **Sprint-Planung** — wöchentliche Sprints pro Projekt, Filter im Kanban
+- **Sprint-Planung** — wöchentliche Sprints, Filter im Kanban
 - **Zeiterfassung** — Stunden pro Projekt/Aufgabe erfassen
 - **Todos** — einfache Aufgabenliste mit geplantem/effektivem Aufwand
-- **Eigenprojekte** — persönliche Projekte einem Lernenden zuordnen
+- **Eigenprojekte** — persönliche Projekte einem Lernpartner zuordnen
+- **Passwort-Reset** — per E-Mail anfordern und setzen
+- **Avatar-Upload** — Profilbild pro Benutzer
+- **E-Mail-Benachrichtigungen** — Leiter kann Benachrichtigungen bei Review-Aufgaben aktivieren
+- **Dark Mode** — System-/manuelles Umschalten
+- **Footer-Links** — konfigurierbare Links (verwaltet durch Leiter)
 - **Rollen** — drei Rollen mit abgestuftem Zugriff:
-  - **Leiter** — Vollzugriff, verwaltet Benutzer, Projekte, Sprints und Mentoren
-  - **Lernender** — sieht eigene/zugewiesene Projekte und eigene Zeiterfassung
-  - **Mentor** — read-only Zugriff auf Daten der zugewiesenen Lernenden; kein Schreibzugriff
+  - **Leiter** — Vollzugriff, verwaltet Benutzer, Projekte, Sprints und Coaches
+  - **Lernpartner** — sieht eigene/zugewiesene Projekte und eigene Zeiterfassung
+  - **Coach** — read-only Zugriff auf Daten der zugewiesenen Lernpartner; kein Schreibzugriff
 
 ---
 
@@ -113,25 +130,35 @@ Das Backend muss separat laufen (siehe `abteilung-webit-api`).
 - API-Calls ausschliesslich über `src/api/index.js`
 - Jeder Datensatz-Typ hat einen eigenen Pinia-Store in `src/stores/`
 - Keine TypeScript — plain JavaScript + JSDoc bei Bedarf
-- Tailwind-Tokens: `text-hi`, `text-mid`, `text-lo`, `bg-surface`, `bg-lift`, `ring-line`, `text-brand-*`
+- Tailwind-Tokens: `text-hi`, `text-mid`, `text-lo`, `bg-surface`, `bg-lift`, `ring-line`, `border-groove`, `text-brand-*`
+- Logout via `window.location.href` (nicht `router.push`) — erzwingt Pinia-Store-Reset
 
 ---
 
 ## Changelog
+
+### 1.5.0
+- E-Mail-Benachrichtigungen: Toggle im Leiter-Profil bei Review-Aufgaben
+- Kanban-Layout: Board zentriert, TodoList als rechte Sidebar auf breiten Screens
+- Terminologie: Mentor → Coach, Lernende → Lernpartner (nur UI-Labels)
+- Bugfix: Logout erzwingt Page-Reload (verhindert stale Pinia-Store nach Rollenwechsel)
+- Bugfix: Login-Fehler zeigte fälschlich „Sitzung abgelaufen" (401 → 400 im Backend)
 
 ### 1.4.0
 - Kanban-Vorlagen: Projekte als Vorlage speichern, Tasks beim Erstellen übernehmen
 - Vorlagen-Tab in der Projektliste (nur Leiter)
 
 ### 1.3.0
-- Mentor-Rolle: read-only Zugriff auf Lernenden-Daten, Mentor-Zuweisung durch Leiter
+- Coach-Rolle: read-only Zugriff auf Lernenden-Daten, Coach-Zuweisung durch Leiter
 
 ### 1.2.0
 - Sprint-Planung mit Kanban-Filter
 - Footer mit konfigurierbaren Links
 
 ### 1.1.0
-- Hilfe-Modal für Lernende und Mentoren
+- Hilfe-Modal für Lernpartner und Coaches
+- Passwort-Reset per E-Mail
+- Avatar-Upload
 
 ### 1.0.0
 - Erstes Release: Kanban-Board, Zeiterfassung, Todos, Rollen

--- a/docs/howto-lernende.md
+++ b/docs/howto-lernende.md
@@ -51,3 +51,16 @@ Einträge kannst du nachträglich bearbeiten oder löschen. Filtere die Liste na
 ## Passwort ändern
 
 Unter **Mein Bereich** findest du die Möglichkeit, dein Passwort zu ändern.
+
+## Arbeitszeiten SBW Neue Medien
+
+Gemäss [Mitteilung Lernhausleiter](https://teams.cloud.microsoft/l/message/19:e4eb1dbb635e410491f303244a1332b6@thread.skype/1754570133525?tenantId=ff4e577a-f11b-4e9f-8136-8c70a74eaab7&groupId=adb5450a-b99c-4ae4-9ccb-6cc3dfbf3b9d&parentMessageId=1754570133525&teamName=InfoHub%20NM%20RH&channelName=GL%20Informationen%20SBW%20Neue%20Medien&createdTime=1754570133525)
+Was|Wann
+--|--
+Arbeitsstart|08.00 Uhr
+Vormittagspause|10:00 – 10:15 Uhr (15 Minuten)
+Mittagspause|12:15 – 13:10 Uhr (55 Minuten)
+Nachmittagspause|15:10 – 15:20 Uhr (10 Minuten)
+Arbeitsschluss|17:05 Uhr
+
+Vormittags ist Schule BM/BF, am Mittwoch findet dann noch die SOL / Lerndokumentation stunden statt. Es bleiben also pro Tag Brutto 2Std. + 1Std.45Min = 3Std. 45Min. 

--- a/docs/howto-mentoren.md
+++ b/docs/howto-mentoren.md
@@ -45,3 +45,17 @@ Du kannst die Einträge nur lesen, nicht ändern.
 | Aufgaben erstellen / bearbeiten | Nein |
 | Zeiteinträge erstellen / bearbeiten | Nein |
 | Lernende verwalten | Nein |
+
+
+## Arbeitszeiten SBW Neue Medien
+
+Gemäss [Mitteilung Lernhausleiter](https://teams.cloud.microsoft/l/message/19:e4eb1dbb635e410491f303244a1332b6@thread.skype/1754570133525?tenantId=ff4e577a-f11b-4e9f-8136-8c70a74eaab7&groupId=adb5450a-b99c-4ae4-9ccb-6cc3dfbf3b9d&parentMessageId=1754570133525&teamName=InfoHub%20NM%20RH&channelName=GL%20Informationen%20SBW%20Neue%20Medien&createdTime=1754570133525)
+Was|Wann
+--|--
+Arbeitsstart|08.00 Uhr
+Vormittagspause|10:00 – 10:15 Uhr (15 Minuten)
+Mittagspause|12:15 – 13:10 Uhr (55 Minuten)
+Nachmittagspause|15:10 – 15:20 Uhr (10 Minuten)
+Arbeitsschluss|17:05 Uhr
+
+Vormittags ist Schule BM/BF, am Mittwoch findet dann noch die SOL / Lerndokumentation stunden statt. Es bleiben also pro Tag Brutto 2Std. + 1Std.45Min = 3Std. 45Min.


### PR DESCRIPTION
Brings the README up to date with all changes since 1.4.0.

- Complete component and view lists
- Added `/passwort-reset` route, fixed role labels (Coach/Lernpartner)
- Features: email notifications, dark mode, avatar, password reset, footer
- Changelog entry for 1.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)