### PR TITLE
feat: duplicate task card

### DIFF
--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -30,6 +30,7 @@
           :key="task.id"
           :task="task"
           :readonly="readonly"
+          @duplicate="$emit('duplicate', $event)"
           @edit="$emit('edit', $event)"
           @delete="$emit('delete', $event)"
         />
@@ -47,7 +48,7 @@ import { ref } from 'vue'
 import KanbanCard from './KanbanCard.vue'
 
 const props = defineProps({ tasks: Array, readonly: Boolean })
-const emit  = defineEmits(['move', 'add', 'edit', 'delete'])
+const emit  = defineEmits(['move', 'add', 'duplicate', 'edit', 'delete'])
 
 const columns = [
   { status: 'offen',     label: 'Offen',    dot: 'bg-lo' },

--- a/src/components/KanbanCard.vue
+++ b/src/components/KanbanCard.vue
@@ -9,6 +9,13 @@
     <div class="flex items-start justify-between gap-2">
       <p class="text-sm font-medium text-hi leading-snug">{{ task.title }}</p>
       <div v-if="!readonly" class="flex gap-1 shrink-0">
+        <button @click.stop="$emit('duplicate', task)"
+                class="text-lo hover:text-brand-600 transition-colors" title="Duplizieren">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+          </svg>
+        </button>
         <button @click.stop="$emit('edit', task)"
                 class="text-lo hover:text-brand-600 transition-colors">
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -72,7 +79,7 @@ import UserAvatar from './UserAvatar.vue'
 import MarkdownRenderer from './MarkdownRenderer.vue'
 
 const props = defineProps({ task: Object, readonly: Boolean })
-defineEmits(['edit', 'delete'])
+defineEmits(['duplicate', 'edit', 'delete'])
 
 const dragging = ref(false)
 

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -47,7 +47,7 @@
       <div class="flex flex-col xl:flex-row gap-6 max-w-7xl mx-auto">
         <div class="flex-1 min-w-0">
           <KanbanBoard :tasks="filteredTasks" :readonly="auth.isMentor"
-                       @move="moveTask" @add="addTask" @edit="openEditTask" @delete="deleteTask" />
+                       @move="moveTask" @add="addTask" @duplicate="duplicateTask" @edit="openEditTask" @delete="deleteTask" />
         </div>
         <div class="xl:w-60 shrink-0">
           <TodoList />
@@ -209,6 +209,21 @@ function addTask(status) {
   serieSprintIds.value = []
   taskForm.value       = { title: '', description: '', status, assignee_id: null, sprint_id: null, planned_duration_min: null }
   showTaskModal.value  = true
+}
+
+function duplicateTask(task) {
+  editingTask.value    = null
+  isSerie.value        = false
+  serieSprintIds.value = []
+  taskForm.value       = {
+    title:                task.title,
+    description:          task.description ?? '',
+    status:               task.status,
+    assignee_id:          null,
+    sprint_id:            task.sprint_id   ?? null,
+    planned_duration_min: task.planned_duration_min ?? null,
+  }
+  showTaskModal.value = true
 }
 
 function openEditTask(task) {


### PR DESCRIPTION
## Summary

- Adds a copy icon button to each `KanbanCard` (between edit and delete, hidden in readonly/mentor mode)
- Clicking it opens the new-task form pre-filled with all fields of the original (title, description, status, sprint, planned time), but with the assignee reset to "Niemanden"
- The user must explicitly re-assign before saving

Pure frontend — no backend changes. The result is an independent new task.

Closes #35

## Test plan

- [ ] Open a project with tasks
- [ ] Hover a card → copy icon appears between edit and delete
- [ ] Click copy icon → "Neue Aufgabe" modal opens, all fields filled except assignee
- [ ] Save → new task appears in the same column/sprint as the original
- [ ] Mentor/readonly view → copy icon not visible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)