### PR TITLE
feat: Dashboard-Layout — kollabierbare Sidebar-Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Vue 3 Single-Page Application für die Verwaltung der webIT-Abteilung.
 
-**Version:** 1.5.3
+**Version:** 1.6.0
 **Repo:** `sbw-neue-medien/abteilung-webit-dash`
 **Backend:** [`sbw-neue-medien/abteilung-webit-api`](https://github.com/sbw-neue-medien/abteilung-webit-api)
 
@@ -42,8 +42,9 @@ src/
 │   ├── MarkdownRenderer.vue
 │   ├── MentorForm.vue
 │   ├── Modal.vue
-│   ├── NavBar.vue
 │   ├── LearnerCard.vue
+│   ├── SideBar.vue
+│   ├── TopBar.vue
 │   ├── ProjectForm.vue
 │   ├── SprintPanel.vue
 │   ├── StatusBadge.vue
@@ -71,6 +72,9 @@ src/
 │   ├── SprintsView.vue
 │   ├── TimeEntryView.vue
 │   └── WerkstattView.vue
+├── composables/  # Wiederverwendbare Composition-Funktionen
+│   ├── useDarkMode.js
+│   └── useNavLinks.js
 └── router/       # Route-Definitionen
 ```
 
@@ -141,6 +145,14 @@ Das Backend muss separat laufen (siehe `abteilung-webit-api`).
 ---
 
 ## Changelog
+
+### 1.6.0
+- Dashboard-Layout: kollabierbare Sidebar-Navigation ersetzt die Top-Navigationsbar
+- Sidebar: Icon + Label (expanded) / nur Icon mit Tooltip (collapsed), Zustand in localStorage
+- TopBar: Logo, Werkstatt-Link (Leiter), Dark-Mode, Hilfe, Username, Logout
+- Werkstatt-Link aus Sidebar in TopBar verschoben (Leiter-only)
+- Mobile: Icon-Only Bottom-Navigation statt Sidebar (`sm:hidden`)
+- `useNavLinks.js`: geteiltes Composable für Sidebar und Bottom-Nav
 
 ### 1.5.3
 - Lernpartner deaktivieren: Leiter kann Aktiv-Checkbox pro Lernpartner setzen

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "webit-abteilung",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,25 @@
           <Footer />
         </main>
       </div>
+
+      <!-- Mobile bottom nav -->
+      <nav class="sm:hidden flex shrink-0 bg-black dark:bg-zinc-950 border-t border-white/10">
+        <RouterLink
+          v-for="link in links"
+          :key="link.to"
+          :to="link.to"
+          :title="link.label"
+          :class="[
+            'flex-1 flex flex-col items-center justify-center py-2 gap-0.5 text-xs transition-colors',
+            isActive(link) ? 'text-white' : 'text-neutral-500 hover:text-neutral-300'
+          ]">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" :d="link.icon" />
+          </svg>
+        </RouterLink>
+      </nav>
     </template>
+
     <main v-else class="flex-1 overflow-y-auto">
       <RouterView />
     </main>
@@ -17,10 +35,19 @@
 </template>
 
 <script setup>
+import { useRoute } from 'vue-router'
 import TopBar from './components/TopBar.vue'
 import SideBar from './components/SideBar.vue'
 import Footer from './components/Footer.vue'
 import { useAuthStore } from './stores/auth.js'
+import { useNavLinks } from './composables/useNavLinks.js'
 
-const auth = useAuthStore()
+const auth  = useAuthStore()
+const route = useRoute()
+const { links } = useNavLinks()
+
+function isActive(link) {
+  if (link.to === '/') return route.path === '/'
+  return route.path.startsWith(link.to)
+}
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,24 @@
 <template>
-  <div class="min-h-screen flex flex-col bg-bg text-hi">
-    <NavBar v-if="auth.isLoggedIn" />
-    <main class="flex-1">
+  <div class="h-screen flex flex-col bg-bg text-hi overflow-hidden">
+    <template v-if="auth.isLoggedIn">
+      <TopBar />
+      <div class="flex flex-1 overflow-hidden">
+        <SideBar />
+        <main class="flex-1 overflow-y-auto">
+          <RouterView />
+          <Footer />
+        </main>
+      </div>
+    </template>
+    <main v-else class="flex-1 overflow-y-auto">
       <RouterView />
     </main>
-    <Footer v-if="auth.isLoggedIn" />
   </div>
 </template>
 
 <script setup>
-import NavBar from './components/NavBar.vue'
+import TopBar from './components/TopBar.vue'
+import SideBar from './components/SideBar.vue'
 import Footer from './components/Footer.vue'
 import { useAuthStore } from './stores/auth.js'
 

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,0 +1,86 @@
+<template>
+  <aside :class="['flex flex-col bg-black dark:bg-zinc-950 text-white shrink-0 transition-[width] duration-200 overflow-hidden', expanded ? 'w-52' : 'w-14']">
+    <nav class="flex-1 py-3 flex flex-col gap-0.5 px-2 overflow-y-auto overflow-x-hidden">
+      <RouterLink
+        v-for="link in links"
+        :key="link.to"
+        :to="link.to"
+        :title="!expanded ? link.label : undefined"
+        :class="[
+          'flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors',
+          isActive(link)
+            ? 'text-white bg-white/15'
+            : 'text-neutral-400 hover:text-white hover:bg-white/10'
+        ]">
+        <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" :d="link.icon" />
+        </svg>
+        <span v-show="expanded" class="truncate">{{ link.label }}</span>
+      </RouterLink>
+    </nav>
+
+    <button
+      @click="toggleExpanded"
+      :title="expanded ? 'Einklappen' : 'Ausklappen'"
+      class="flex items-center justify-center h-10 border-t border-white/10 text-neutral-500 hover:text-white transition-colors shrink-0">
+      <svg class="w-4 h-4 transition-transform duration-200" :class="expanded ? '' : 'rotate-180'"
+           fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+      </svg>
+    </button>
+  </aside>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useAuthStore } from '../stores/auth.js'
+
+const auth  = useAuthStore()
+const route = useRoute()
+
+const expanded = ref(localStorage.getItem('sidebar-expanded') !== 'false')
+
+function toggleExpanded() {
+  expanded.value = !expanded.value
+  localStorage.setItem('sidebar-expanded', String(expanded.value))
+}
+
+function isActive(link) {
+  if (link.to === '/') return route.path === '/'
+  return route.path.startsWith(link.to)
+}
+
+const ICONS = {
+  dashboard:    'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6',
+  projekte:     'M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V7z',
+  zeiterfassung:'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+  bereich:      'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+  sprints:      'M13 10V3L4 14h7v7l9-11h-7z',
+  lernende:     'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z',
+  coaches:      'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+  werkstatt:    'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065zM15 12a3 3 0 11-6 0 3 3 0 016 0z',
+}
+
+const links = computed(() => {
+  if (auth.isMentor) return [
+    { to: '/',              label: 'Dashboard',     icon: ICONS.dashboard     },
+    { to: '/projekte',      label: 'Projekte',      icon: ICONS.projekte      },
+    { to: '/zeiterfassung', label: 'Zeiterfassung', icon: ICONS.zeiterfassung },
+    { to: '/lernende',      label: 'Lernpartner',   icon: ICONS.lernende      },
+  ]
+  const base = [
+    { to: '/',              label: 'Dashboard',     icon: ICONS.dashboard     },
+    { to: '/projekte',      label: 'Projekte',      icon: ICONS.projekte      },
+    { to: '/zeiterfassung', label: 'Zeiterfassung', icon: ICONS.zeiterfassung },
+    { to: '/mein-bereich',  label: 'Mein Bereich',  icon: ICONS.bereich       },
+  ]
+  if (auth.isLeiter) {
+    base.push({ to: '/sprints',   label: 'Sprints',     icon: ICONS.sprints   })
+    base.push({ to: '/lernende',  label: 'Lernpartner', icon: ICONS.lernende  })
+    base.push({ to: '/mentoren',  label: 'Coaches',     icon: ICONS.coaches   })
+    base.push({ to: '/werkstatt', label: 'Werkstatt',   icon: ICONS.werkstatt })
+  }
+  return base
+})
+</script>

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside :class="['flex flex-col bg-black dark:bg-zinc-950 text-white shrink-0 transition-[width] duration-200 overflow-hidden', expanded ? 'w-52' : 'w-14']">
+  <aside :class="['hidden sm:flex flex-col bg-black dark:bg-zinc-950 text-white shrink-0 transition-[width] duration-200 overflow-hidden', expanded ? 'w-52' : 'w-14']">
     <nav class="flex-1 py-3 flex flex-col gap-0.5 px-2 overflow-y-auto overflow-x-hidden">
       <RouterLink
         v-for="link in links"
@@ -32,12 +32,12 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { useAuthStore } from '../stores/auth.js'
+import { useNavLinks } from '../composables/useNavLinks.js'
 
-const auth  = useAuthStore()
 const route = useRoute()
+const { links } = useNavLinks()
 
 const expanded = ref(localStorage.getItem('sidebar-expanded') !== 'false')
 
@@ -50,37 +50,4 @@ function isActive(link) {
   if (link.to === '/') return route.path === '/'
   return route.path.startsWith(link.to)
 }
-
-const ICONS = {
-  dashboard:    'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6',
-  projekte:     'M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V7z',
-  zeiterfassung:'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
-  bereich:      'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
-  sprints:      'M13 10V3L4 14h7v7l9-11h-7z',
-  lernende:     'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z',
-  coaches:      'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
-  werkstatt:    'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065zM15 12a3 3 0 11-6 0 3 3 0 016 0z',
-}
-
-const links = computed(() => {
-  if (auth.isMentor) return [
-    { to: '/',              label: 'Dashboard',     icon: ICONS.dashboard     },
-    { to: '/projekte',      label: 'Projekte',      icon: ICONS.projekte      },
-    { to: '/zeiterfassung', label: 'Zeiterfassung', icon: ICONS.zeiterfassung },
-    { to: '/lernende',      label: 'Lernpartner',   icon: ICONS.lernende      },
-  ]
-  const base = [
-    { to: '/',              label: 'Dashboard',     icon: ICONS.dashboard     },
-    { to: '/projekte',      label: 'Projekte',      icon: ICONS.projekte      },
-    { to: '/zeiterfassung', label: 'Zeiterfassung', icon: ICONS.zeiterfassung },
-    { to: '/mein-bereich',  label: 'Mein Bereich',  icon: ICONS.bereich       },
-  ]
-  if (auth.isLeiter) {
-    base.push({ to: '/sprints',   label: 'Sprints',     icon: ICONS.sprints   })
-    base.push({ to: '/lernende',  label: 'Lernpartner', icon: ICONS.lernende  })
-    base.push({ to: '/mentoren',  label: 'Coaches',     icon: ICONS.coaches   })
-    base.push({ to: '/werkstatt', label: 'Werkstatt',   icon: ICONS.werkstatt })
-  }
-  return base
-})
 </script>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -1,0 +1,49 @@
+<template>
+  <header class="h-14 bg-black dark:bg-zinc-950 text-white flex items-center justify-between px-4 shrink-0">
+    <span class="font-bold text-lg tracking-tight">WebIT Abteilung</span>
+    <div class="flex items-center gap-2">
+      <span class="text-sm text-neutral-400 hidden sm:block mr-1">{{ auth.user?.name }}</span>
+      <button @click="toggle"
+        class="p-1.5 rounded-md text-neutral-400 hover:text-white hover:bg-white/10 transition-colors"
+        :title="isDark ? 'Helles Design' : 'Dunkles Design'">
+        <svg v-if="isDark" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+        </svg>
+        <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+        </svg>
+      </button>
+      <button @click="showHelp = true"
+        class="p-1.5 rounded-md text-neutral-400 hover:text-white hover:bg-white/10 transition-colors"
+        title="Hilfe">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+      </button>
+      <button @click="logout"
+        class="text-xs px-2.5 py-1 rounded-md bg-white/10 hover:bg-white/20 transition-colors">
+        Abmelden
+      </button>
+    </div>
+  </header>
+  <HelpModal v-model="showHelp" />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useAuthStore } from '../stores/auth.js'
+import { useDarkMode } from '../composables/useDarkMode.js'
+import HelpModal from './HelpModal.vue'
+
+const auth     = useAuthStore()
+const { isDark, toggle } = useDarkMode()
+const showHelp = ref(false)
+
+function logout() {
+  auth.logout()
+  window.location.href = '/login'
+}
+</script>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -1,6 +1,17 @@
 <template>
   <header class="h-14 bg-black dark:bg-zinc-950 text-white flex items-center justify-between px-4 shrink-0">
-    <span class="font-bold text-lg tracking-tight">WebIT Abteilung</span>
+    <div class="flex items-center gap-4">
+      <span class="font-bold text-lg tracking-tight">WebIT Abteilung</span>
+      <RouterLink v-if="auth.isLeiter" to="/werkstatt"
+        class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm text-neutral-400 hover:text-white hover:bg-white/10 transition-colors"
+        :class="{ '!text-white !bg-white/15': route.path === '/werkstatt' }">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75"
+            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065zM15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+        <span class="hidden sm:inline">Werkstatt</span>
+      </RouterLink>
+    </div>
     <div class="flex items-center gap-2">
       <span class="text-sm text-neutral-400 hidden sm:block mr-1">{{ auth.user?.name }}</span>
       <button @click="toggle"
@@ -34,11 +45,13 @@
 
 <script setup>
 import { ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useDarkMode } from '../composables/useDarkMode.js'
 import HelpModal from './HelpModal.vue'
 
 const auth     = useAuthStore()
+const route    = useRoute()
 const { isDark, toggle } = useDarkMode()
 const showHelp = ref(false)
 

--- a/src/composables/useNavLinks.js
+++ b/src/composables/useNavLinks.js
@@ -1,0 +1,40 @@
+import { computed } from 'vue'
+import { useAuthStore } from '../stores/auth.js'
+
+const ICONS = {
+  dashboard:    'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6',
+  projekte:     'M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V7z',
+  zeiterfassung:'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+  bereich:      'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
+  sprints:      'M13 10V3L4 14h7v7l9-11h-7z',
+  lernende:     'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z',
+  coaches:      'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+  werkstatt:    'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065zM15 12a3 3 0 11-6 0 3 3 0 016 0z',
+}
+
+export function useNavLinks() {
+  const auth = useAuthStore()
+
+  const links = computed(() => {
+    if (auth.isMentor) return [
+      { to: '/',              label: 'Dashboard',     icon: ICONS.dashboard     },
+      { to: '/projekte',      label: 'Projekte',      icon: ICONS.projekte      },
+      { to: '/zeiterfassung', label: 'Zeiterfassung', icon: ICONS.zeiterfassung },
+      { to: '/lernende',      label: 'Lernpartner',   icon: ICONS.lernende      },
+    ]
+    const base = [
+      { to: '/',              label: 'Dashboard',     icon: ICONS.dashboard     },
+      { to: '/projekte',      label: 'Projekte',      icon: ICONS.projekte      },
+      { to: '/zeiterfassung', label: 'Zeiterfassung', icon: ICONS.zeiterfassung },
+      { to: '/mein-bereich',  label: 'Mein Bereich',  icon: ICONS.bereich       },
+    ]
+    if (auth.isLeiter) {
+      base.push({ to: '/sprints',  label: 'Sprints',     icon: ICONS.sprints  })
+      base.push({ to: '/lernende', label: 'Lernpartner', icon: ICONS.lernende })
+      base.push({ to: '/mentoren', label: 'Coaches',     icon: ICONS.coaches  })
+    }
+    return base
+  })
+
+  return { links, ICONS }
+}


### PR DESCRIPTION
## Änderungen

- **`App.vue`**: `min-h-screen flex-col` → `h-screen flex-col`; TopBar oben, darunter `flex-row` mit SideBar + scrollbarem `<main>`
- **`TopBar.vue`** (neu): Logo, Dark-Mode-Toggle, Hilfe, Username, Logout — keine Nav-Links mehr
- **`SideBar.vue`** (neu):
  - Expanded (`w-52`): Icon + Label pro Nav-Item
  - Collapsed (`w-14`): nur Icon + `title`-Tooltip
  - Aktiver Link hervorgehoben (`isActive()` — Dashboard-Fix für exaktes `/`)
  - Collapse-Toggle-Button unten mit Chevron-Animation
  - State wird in `localStorage` gespeichert und beim Laden wiederhergestellt
  - Rollenbasiert: Mentor sieht 4 Links, Leiter 8 Links

## NavBar.vue

Wird nicht mehr in `App.vue` verwendet — kann in einem Folge-Commit entfernt werden.

## Noch offen (separate Issues)

- #48 Mobile-Handling
- #49 TodoList in Sidebar

Closes #47