### PR TITLE
feat: Role management UI — permission matrix (Phase 4)

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -89,4 +89,6 @@ export const api = {
   createFooterLink: (body)         => req('/footer-links', { method: 'POST', body: JSON.stringify(body) }),
   updateFooterLink: (id, body)     => req(`/footer-links/${id}`, { method: 'PUT', body: JSON.stringify(body) }),
   deleteFooterLink: (id)           => req(`/footer-links/${id}`, { method: 'DELETE' }),
+  getRoles: ()                     => req('/roles'),
+  updateRolePermissions: (role, permissions) => req(`/roles/${role}/permissions`, { method: 'PUT', body: JSON.stringify({ permissions }) }),
 }

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -63,7 +63,8 @@ const links = computed(() => {
   if (auth.can('sprints.manage')) base.push({ to: '/sprints',       label: 'Sprints' })
   if (auth.can('users.list'))     base.push({ to: '/lernende',      label: 'Lernpartner' })
   if (auth.can('mentors.manage')) base.push({ to: '/mentoren',      label: 'Coaches' })
-  if (auth.can('werkstatt.view')) base.push({ to: '/werkstatt',     label: 'Werkstatt' })
+  if (auth.can('werkstatt.view'))   base.push({ to: '/werkstatt',   label: 'Werkstatt' })
+  if (auth.can('settings.manage')) base.push({ to: '/rollen',      label: 'Berechtigungen' })
   return base
 })
 

--- a/src/composables/useNavLinks.js
+++ b/src/composables/useNavLinks.js
@@ -10,6 +10,7 @@ const ICONS = {
   lernende:     'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z',
   coaches:      'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
   werkstatt:    'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065zM15 12a3 3 0 11-6 0 3 3 0 016 0z',
+  rollen:       'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01',
 }
 
 export function useNavLinks() {
@@ -25,7 +26,8 @@ export function useNavLinks() {
     if (auth.can('sprints.manage')) base.push({ to: '/sprints',      label: 'Sprints',       icon: ICONS.sprints  })
     if (auth.can('users.list'))     base.push({ to: '/lernende',     label: 'Lernpartner',   icon: ICONS.lernende })
     if (auth.can('mentors.manage')) base.push({ to: '/mentoren',     label: 'Coaches',       icon: ICONS.coaches  })
-    if (auth.can('werkstatt.view')) base.push({ to: '/werkstatt',    label: 'Werkstatt',     icon: ICONS.werkstatt})
+    if (auth.can('werkstatt.view'))   base.push({ to: '/werkstatt',  label: 'Werkstatt',       icon: ICONS.werkstatt })
+    if (auth.can('settings.manage')) base.push({ to: '/rollen',     label: 'Berechtigungen',  icon: ICONS.rollen   })
     return base
   })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ const routes = [
   { path: '/mentoren',     name: 'mentors',  component: () => import('../views/MentorsView.vue'),     meta: { permission: 'mentors.manage' } },
   { path: '/werkstatt',   name: 'werkstatt', component: () => import('../views/WerkstattView.vue'),  meta: { permission: 'werkstatt.view' } },
   { path: '/mein-bereich', name: 'my-area',  component: () => import('../views/MyAreaView.vue') },
+  { path: '/rollen',       name: 'roles',    component: () => import('../views/RolesView.vue'),    meta: { permission: 'settings.manage' } },
 ]
 
 const router = createRouter({

--- a/src/views/RolesView.vue
+++ b/src/views/RolesView.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="max-w-5xl mx-auto px-4 py-8 space-y-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold text-hi">Rollenverwaltung</h1>
+    </div>
+
+    <p class="text-sm text-lo">
+      Änderungen gelten sofort für alle API-Zugriffe. Frontend-Sichtbarkeit (Buttons, Nav-Einträge)
+      wird erst nach erneutem Anmelden aktualisiert.
+    </p>
+
+    <div v-if="loading" class="text-lo italic text-center py-12">Laden…</div>
+
+    <div v-else class="card overflow-x-auto p-0">
+      <table class="min-w-full text-sm">
+        <thead class="bg-lift border-b border-groove">
+          <tr>
+            <th class="px-4 py-3 text-left font-medium text-mid w-full">Berechtigung</th>
+            <th v-for="role in roles" :key="role"
+                class="px-6 py-3 text-center font-semibold text-hi whitespace-nowrap capitalize min-w-[110px]">
+              {{ ROLE_LABELS[role] }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="group in groups" :key="group.label">
+            <tr class="bg-brand-subtle/40">
+              <td :colspan="roles.length + 1"
+                  class="px-4 py-1.5 text-xs font-semibold text-brand-700 uppercase tracking-wide">
+                {{ group.label }}
+              </td>
+            </tr>
+            <tr v-for="perm in group.permissions" :key="perm.key"
+                class="border-t border-groove hover:bg-lift transition-colors">
+              <td class="px-4 py-2.5">
+                <span class="font-mono text-xs text-mid">{{ perm.key }}</span>
+                <span class="text-lo text-xs ml-2">{{ perm.description }}</span>
+              </td>
+              <td v-for="role in roles" :key="role" class="px-6 py-2.5 text-center">
+                <input
+                  type="checkbox"
+                  :checked="perm.grants.includes(role)"
+                  :disabled="saving[role]"
+                  class="rounded border-line text-brand-600 focus:ring-brand-500 cursor-pointer"
+                  @change="toggle(role, perm.key, $event.target.checked)"
+                />
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api/index.js'
+
+const ROLE_LABELS = {
+  leiter:    'Leiter',
+  lernender: 'Lernpartner',
+  mentor:    'Coach',
+}
+
+const GROUP_LABELS = {
+  projects:     'Projekte',
+  tasks:        'Aufgaben',
+  sprints:      'Sprints',
+  time_entries: 'Zeiteinträge',
+  todos:        'Todos',
+  users:        'Benutzer',
+  mentors:      'Coaches',
+  reports:      'Berichte',
+  settings:     'Einstellungen',
+  werkstatt:    'Werkstatt',
+}
+
+const loading     = ref(true)
+const roles       = ref([])
+const permissions = ref([])
+const saving      = ref({})
+
+const groups = computed(() => {
+  const map = {}
+  for (const p of permissions.value) {
+    const prefix = p.key.split('.')[0]
+    if (!map[prefix]) map[prefix] = []
+    map[prefix].push(p)
+  }
+  return Object.entries(map).map(([prefix, perms]) => ({
+    label:       GROUP_LABELS[prefix] ?? prefix,
+    permissions: perms,
+  }))
+})
+
+onMounted(async () => {
+  const data  = await api.getRoles()
+  roles.value = data.roles
+  permissions.value = data.permissions
+  roles.value.forEach(r => (saving.value[r] = false))
+  loading.value = false
+})
+
+async function toggle(role, key, granted) {
+  const perm = permissions.value.find(p => p.key === key)
+  if (!perm) return
+
+  // Optimistic update
+  if (granted) {
+    perm.grants.push(role)
+  } else {
+    perm.grants = perm.grants.filter(r => r !== role)
+  }
+
+  saving.value[role] = true
+  try {
+    const current = permissions.value
+      .filter(p => p.grants.includes(role))
+      .map(p => p.key)
+    await api.updateRolePermissions(role, current)
+  } catch (err) {
+    // Roll back on error
+    if (granted) {
+      perm.grants = perm.grants.filter(r => r !== role)
+    } else {
+      perm.grants.push(role)
+    }
+    alert('Fehler beim Speichern: ' + err.message)
+  } finally {
+    saving.value[role] = false
+  }
+}
+</script>


### PR DESCRIPTION
Part of #37 / follow-up to #38. Requires the matching API PR to be merged first.

## Summary

First user-visible change from the permission system: leiter can now edit role permissions directly in the app without a deploy.

- `/rollen` — new leiter-only route showing a permission matrix
- 39 permissions grouped by category (Projekte, Aufgaben, Sprints, Zeiteinträge, Todos, Benutzer, Coaches, Berichte, Einstellungen, Werkstatt)
- Three role columns (Leiter, Lernpartner, Coach) with checkboxes
- Toggle saves immediately via `PUT /roles/{role}/permissions` with optimistic update and rollback on error
- Info note: API access changes take effect immediately; frontend UI visibility (buttons, nav) updates after re-login
- "Berechtigungen" nav entry added (leiter-only, `can('settings.manage')`)

## Test plan

- [ ] Log in as leiter — "Berechtigungen" appears in nav
- [ ] `/rollen` shows all 39 permissions grouped correctly
- [ ] Toggle a checkbox — saves without page reload, checkbox stays in new state
- [ ] Log in as lernender or mentor — `/rollen` redirects to `/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)