### PR TITLE
feat: Project-scoped permissions UI (Phase 6)

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -92,6 +92,9 @@ export const api = {
   deleteFooterLink: (id)           => req(`/footer-links/${id}`, { method: 'DELETE' }),
   getUserPermissions: (id)          => req(`/users/${id}/permissions`),
   updateUserPermissions: (id, overrides) => req(`/users/${id}/permissions`, { method: 'PUT', body: JSON.stringify({ overrides }) }),
+  getProjectPermissions: (id)                      => req(`/projects/${id}/permissions`),
+  updateProjectPermissions: (id, userId, perms)    => req(`/projects/${id}/permissions/${userId}`, { method: 'PUT', body: JSON.stringify({ permissions: perms }) }),
+  deleteProjectPermissions: (id, userId)           => req(`/projects/${id}/permissions/${userId}`, { method: 'DELETE' }),
   getRoles: ()                     => req('/roles'),
   updateRolePermissions: (role, permissions) => req(`/roles/${role}/permissions`, { method: 'PUT', body: JSON.stringify({ permissions }) }),
 }

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -98,7 +98,7 @@ watch(() => props.project, (p) => {
     status:      p.status,
     is_personal: !!p.is_personal,
     owner_id:    p.is_personal ? (p.owner_id ?? null) : null,
-    member_ids:  (p.members ?? []).map(m => m.id),
+    member_ids:  p.members ? p.members.map(m => m.id) : (p.member_ids ?? []),
     is_template: false,
     template_id: null,
   }

--- a/src/components/ProjectPermissionsPanel.vue
+++ b/src/components/ProjectPermissionsPanel.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="mt-6 max-w-7xl mx-auto space-y-4">
+    <h3 class="text-sm font-semibold text-lo uppercase tracking-wide">Projektberechtigungen</h3>
+
+    <div v-if="loading" class="text-lo italic text-sm">Laden…</div>
+
+    <template v-else>
+      <!-- Existing grants per user -->
+      <div v-if="grants.length" class="space-y-2">
+        <div v-for="g in grants" :key="g.user_id"
+             class="card flex flex-wrap items-start gap-3 py-3">
+          <span class="font-medium text-hi text-sm min-w-[8rem]">{{ g.user_name }}</span>
+          <div class="flex flex-wrap gap-1 flex-1">
+            <span v-for="perm in g.permissions" :key="perm"
+                  class="inline-flex items-center gap-1 text-xs bg-brand-subtle text-brand-700 rounded-full px-2 py-0.5">
+              {{ perm }}
+              <button @click="removePermission(g, perm)"
+                      class="hover:text-red-500 transition-colors leading-none" title="Entfernen">×</button>
+            </span>
+          </div>
+          <button class="btn btn-sm btn-danger shrink-0" @click="removeAll(g)">Alle entfernen</button>
+        </div>
+      </div>
+
+      <!-- Add grant form -->
+      <div class="card flex flex-wrap gap-2 items-end">
+        <div class="flex-1 min-w-[10rem]">
+          <label class="label">Benutzer</label>
+          <select v-model="form.userId" class="input text-sm py-1">
+            <option value="">Benutzer wählen…</option>
+            <option v-for="u in users" :key="u.id" :value="u.id">{{ u.name }}</option>
+          </select>
+        </div>
+        <div class="flex-1 min-w-[12rem]">
+          <label class="label">Berechtigung</label>
+          <select v-model="form.permission" class="input text-sm py-1">
+            <option value="">Berechtigung wählen…</option>
+            <optgroup v-for="group in permGroups" :key="group.label" :label="group.label">
+              <option v-for="p in group.permissions" :key="p.key" :value="p.key">{{ p.key }}</option>
+            </optgroup>
+          </select>
+        </div>
+        <button class="btn btn-sm btn-primary shrink-0"
+                :disabled="!form.userId || !form.permission || saving"
+                @click="addPermission">
+          Hinzufügen
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api/index.js'
+
+const PERM_GROUPS = {
+  projects:     'Projekte',
+  tasks:        'Aufgaben',
+  sprints:      'Sprints',
+  time_entries: 'Zeiteinträge',
+  todos:        'Todos',
+  users:        'Benutzer',
+  mentors:      'Coaches',
+  reports:      'Berichte',
+  settings:     'Einstellungen',
+  werkstatt:    'Werkstatt',
+}
+
+const props = defineProps({
+  projectId: { type: Number, required: true },
+  users:     { type: Array,  required: true },
+})
+
+const loading    = ref(false)
+const saving     = ref(false)
+const grants     = ref([])
+const allPerms   = ref([])
+const form       = ref({ userId: '', permission: '' })
+
+const permGroups = computed(() => {
+  const map = {}
+  for (const p of allPerms.value) {
+    const prefix = p.key.split('.')[0]
+    if (!map[prefix]) map[prefix] = []
+    map[prefix].push(p)
+  }
+  return Object.entries(map).map(([prefix, permissions]) => ({
+    label: PERM_GROUPS[prefix] ?? prefix,
+    permissions,
+  }))
+})
+
+async function load() {
+  loading.value = true
+  try {
+    const [permsData, grantsData] = await Promise.all([
+      api.getRoles(),
+      api.getProjectPermissions(props.projectId),
+    ])
+    allPerms.value = permsData.permissions
+    grants.value   = grantsData
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+
+async function addPermission() {
+  if (!form.value.userId || !form.value.permission) return
+  saving.value = true
+  try {
+    const existing = grants.value.find(g => g.user_id === form.value.userId)
+    const current  = existing ? [...existing.permissions] : []
+    if (!current.includes(form.value.permission)) current.push(form.value.permission)
+    await api.updateProjectPermissions(props.projectId, form.value.userId, current)
+    form.value.userId = ''
+    form.value.permission = ''
+    await load()
+  } catch (err) {
+    alert(err.message)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function removePermission(grant, perm) {
+  const updated = grant.permissions.filter(p => p !== perm)
+  if (updated.length === 0) {
+    await api.deleteProjectPermissions(props.projectId, grant.user_id)
+  } else {
+    await api.updateProjectPermissions(props.projectId, grant.user_id, updated)
+  }
+  await load()
+}
+
+async function removeAll(grant) {
+  await api.deleteProjectPermissions(props.projectId, grant.user_id)
+  await load()
+}
+</script>

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -63,6 +63,11 @@
           </span>
         </div>
       </div>
+
+      <ProjectPermissionsPanel
+        v-if="auth.can('projects.manage_members')"
+        :project-id="Number(route.params.id)"
+        :users="allUsers" />
     </template>
     <div v-else class="text-center py-16 text-lo">Projekt nicht gefunden.</div>
 
@@ -161,6 +166,7 @@ import Modal from '../components/Modal.vue'
 import ProjectForm from '../components/ProjectForm.vue'
 import TodoList from '../components/TodoList.vue'
 import MarkdownRenderer from '../components/MarkdownRenderer.vue'
+import ProjectPermissionsPanel from '../components/ProjectPermissionsPanel.vue'
 
 const route      = useRoute()
 const auth       = useAuthStore()

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -54,6 +54,12 @@
             <StatusBadge :status="p.status" />
           </div>
           <p v-if="p.description" class="text-sm text-mid line-clamp-2">{{ markdownPreview(p.description) }}</p>
+          <div v-if="p.member_ids?.length && auth.can('projects.create')" class="flex flex-wrap gap-1">
+            <span v-for="uid in p.member_ids" :key="uid"
+                  class="text-xs bg-brand-subtle text-brand-700 rounded-full px-2 py-0.5">
+              {{ users.list.find(u => u.id === uid)?.name ?? '?' }}
+            </span>
+          </div>
           <div class="flex items-center justify-between mt-auto pt-2 border-t border-groove">
             <span class="text-xs text-lo">{{ p.owner_name }}</span>
             <div v-if="auth.can('projects.create')" class="flex gap-1" @click.stop>


### PR DESCRIPTION
Part of #37 / follow-up to Phase 5. Requires the matching API PR.

ProjectPermissionsPanel.vue shown below members section on project detail (leiter only): lists per-user grants as removable chips, add form with user + permission select. ProjectDetailView imports the panel and reuses allUsers.

Test: grant tasks.create for a lernender on project X → add task button visible for that project only; remove chip → reverts to role default.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)