### PR TITLE
fix: member chips missing on first load after login (#56)

### DIFF
--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -221,6 +221,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useProjectsStore } from '../stores/projects.js'
+import { useUsersStore } from '../stores/users.js'
 import { useTimeEntriesStore } from '../stores/timeEntries.js'
 import { api } from '../api/index.js'
 import StatusBadge from '../components/StatusBadge.vue'
@@ -228,6 +229,7 @@ import UserAvatar from '../components/UserAvatar.vue'
 
 const auth      = useAuthStore()
 const projects  = useProjectsStore()
+const users     = useUsersStore()
 const timeStore = useTimeEntriesStore()
 const router    = useRouter()
 
@@ -242,6 +244,7 @@ const learnerHours = ref([])
 
 onMounted(async () => {
   const calls = [projects.fetchAll()]
+  if (auth.can('projects.create')) calls.push(users.fetchAll())
   if (!auth.isMentor) calls.push(timeStore.fetchReport({ from: monday, to: today }))
   if (auth.can('werkstatt.view')) calls.push(
     api.getDashboardStats().then(d => {


### PR DESCRIPTION
## Problem
After logging in, member chips in the project overview showed `?` or were missing entirely. Navigating away and back fixed it.

## Root cause
`ProjectsView.onMounted` calls `projects.fetchAll()` and `users.fetchAll()` in parallel. `projects.list` was already populated by the dashboard's fetch, so project cards rendered immediately — but `users.list` was still empty, leaving all names unresolved.

## Fix
Add `users.fetchAll()` to `DashboardView.onMounted` (guarded by `projects.create` permission, same as in ProjectsView). Since the dashboard is the landing page after login, `users.list` is warm before the user ever reaches `/projekte`.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)