### PR TITLE
feat: role management & per-user permission overrides

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -27,6 +27,7 @@ async function req(path, options = {}) {
 export const api = {
   login: (body)                  => req('/auth/login', { method: 'POST', body: JSON.stringify(body) }),
   refreshToken: ()               => req('/auth/refresh', { method: 'POST' }),
+  getMyPermissions: ()           => req('/auth/permissions'),
   forgotPassword: (body)         => req('/auth/forgot-password', { method: 'POST', body: JSON.stringify(body) }),
   resetPassword: (body)          => req('/auth/reset-password', { method: 'POST', body: JSON.stringify(body) }),
   sendResetEmail: (id)           => req(`/users/${id}/send-reset-email`, { method: 'POST' }),

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -90,4 +90,6 @@ export const api = {
   createFooterLink: (body)         => req('/footer-links', { method: 'POST', body: JSON.stringify(body) }),
   updateFooterLink: (id, body)     => req(`/footer-links/${id}`, { method: 'PUT', body: JSON.stringify(body) }),
   deleteFooterLink: (id)           => req(`/footer-links/${id}`, { method: 'DELETE' }),
+  getRoles: ()                     => req('/roles'),
+  updateRolePermissions: (role, permissions) => req(`/roles/${role}/permissions`, { method: 'PUT', body: JSON.stringify({ permissions }) }),
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -90,6 +90,8 @@ export const api = {
   createFooterLink: (body)         => req('/footer-links', { method: 'POST', body: JSON.stringify(body) }),
   updateFooterLink: (id, body)     => req(`/footer-links/${id}`, { method: 'PUT', body: JSON.stringify(body) }),
   deleteFooterLink: (id)           => req(`/footer-links/${id}`, { method: 'DELETE' }),
+  getUserPermissions: (id)          => req(`/users/${id}/permissions`),
+  updateUserPermissions: (id, overrides) => req(`/users/${id}/permissions`, { method: 'PUT', body: JSON.stringify({ overrides }) }),
   getRoles: ()                     => req('/roles'),
   updateRolePermissions: (role, permissions) => req(`/roles/${role}/permissions`, { method: 'PUT', body: JSON.stringify({ permissions }) }),
 }

--- a/src/components/LearnerCard.vue
+++ b/src/components/LearnerCard.vue
@@ -34,6 +34,7 @@
         Reset-E-Mail
       </button>
       <button v-if="u.active" class="btn btn-sm btn-secondary" @click="$emit('edit', u)">Bearbeiten</button>
+      <button v-if="u.active" class="btn btn-sm btn-secondary" @click="$emit('editPermissions', u)" title="Berechtigungen anpassen">Berechtigungen</button>
       <button v-if="u.active" class="btn btn-sm btn-danger" @click="$emit('remove', u)">Löschen</button>
       <label class="flex items-center gap-1.5 text-sm text-mid cursor-pointer ml-auto select-none">
         <input type="checkbox" :checked="!!u.active"
@@ -52,5 +53,5 @@ defineProps({
   u:    { type: Object, required: true },
   auth: { type: Object, required: true },
 })
-defineEmits(['triggerUpload', 'removeAvatar', 'sendReset', 'edit', 'remove', 'toggleActive'])
+defineEmits(['triggerUpload', 'removeAvatar', 'sendReset', 'edit', 'editPermissions', 'remove', 'toggleActive'])
 </script>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -2,7 +2,7 @@
   <Teleport to="body">
     <div v-if="modelValue" class="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div class="absolute inset-0 bg-black/50" @click="$emit('update:modelValue', false)" />
-      <div class="relative w-full max-w-lg bg-surface rounded-2xl shadow-xl p-6 z-10 max-h-[90vh] overflow-y-auto ring-1 ring-line">
+      <div :class="['relative w-full bg-surface rounded-2xl shadow-xl p-6 z-10 max-h-[90vh] overflow-y-auto ring-1 ring-line', wide ? 'max-w-3xl' : 'max-w-lg']">
         <div class="flex items-start justify-between mb-4">
           <h3 class="text-lg font-semibold text-hi">{{ title }}</h3>
           <button @click="$emit('update:modelValue', false)"
@@ -19,6 +19,6 @@
 </template>
 
 <script setup>
-defineProps({ modelValue: Boolean, title: String })
+defineProps({ modelValue: Boolean, title: String, wide: Boolean })
 defineEmits(['update:modelValue'])
 </script>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -63,7 +63,8 @@ const links = computed(() => {
   if (auth.can('sprints.manage')) base.push({ to: '/sprints',       label: 'Sprints' })
   if (auth.can('users.list'))     base.push({ to: '/lernende',      label: 'Lernpartner' })
   if (auth.can('mentors.manage')) base.push({ to: '/mentoren',      label: 'Coaches' })
-  if (auth.can('werkstatt.view')) base.push({ to: '/werkstatt',     label: 'Werkstatt' })
+  if (auth.can('werkstatt.view'))   base.push({ to: '/werkstatt',   label: 'Werkstatt' })
+  if (auth.can('settings.manage')) base.push({ to: '/rollen',      label: 'Berechtigungen' })
   return base
 })
 

--- a/src/components/UserPermissionsModal.vue
+++ b/src/components/UserPermissionsModal.vue
@@ -1,0 +1,152 @@
+<template>
+  <Modal :model-value="modelValue" @update:model-value="$emit('update:modelValue', $event)"
+         :title="`Berechtigungen – ${userName}`" :wide="true">
+
+    <div v-if="loading" class="text-lo italic text-center py-8">Laden…</div>
+
+    <template v-else>
+      <p class="text-xs text-lo mb-4">
+        Überschreibungen gelten sofort. Ohne Überschreibung gilt die Rolle
+        <span class="font-mono font-semibold text-mid">{{ roleLabel }}</span>.
+      </p>
+
+      <div class="overflow-x-auto -mx-4">
+        <table class="min-w-full text-sm">
+          <thead class="bg-lift border-b border-groove">
+            <tr>
+              <th class="px-4 py-2 text-left font-medium text-mid">Berechtigung</th>
+              <th class="px-4 py-2 text-center font-medium text-mid w-24">Rolle</th>
+              <th class="px-4 py-2 text-center font-medium text-mid w-36">Überschreibung</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="group in groups" :key="group.label">
+              <tr class="bg-brand-subtle/40">
+                <td colspan="3" class="px-4 py-1 text-xs font-semibold text-brand-700 uppercase tracking-wide">
+                  {{ group.label }}
+                </td>
+              </tr>
+              <tr v-for="perm in group.permissions" :key="perm.key"
+                  class="border-t border-groove hover:bg-lift transition-colors">
+                <td class="px-4 py-2">
+                  <span class="font-mono text-xs text-mid">{{ perm.key }}</span>
+                </td>
+                <td class="px-4 py-2 text-center">
+                  <span v-if="perm.role_granted"
+                        class="inline-block w-4 h-4 rounded-full bg-brand-500" title="Durch Rolle gewährt" />
+                  <span v-else
+                        class="inline-block w-4 h-4 rounded-full bg-lift border border-groove" title="Durch Rolle nicht gewährt" />
+                </td>
+                <td class="px-4 py-2 text-center">
+                  <select
+                    :value="overrides[perm.key] ?? ''"
+                    :disabled="saving"
+                    class="input py-0.5 text-xs w-full"
+                    @change="setOverride(perm.key, $event.target.value)"
+                  >
+                    <option value="">Rolle</option>
+                    <option value="1">Gewähren</option>
+                    <option value="0">Verweigern</option>
+                  </select>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="flex justify-end gap-2 mt-4 pt-4 border-t border-groove">
+        <button class="btn-secondary" @click="$emit('update:modelValue', false)">Schließen</button>
+        <button class="btn-primary" :disabled="saving" @click="save">
+          {{ saving ? 'Speichern…' : 'Speichern' }}
+        </button>
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import Modal from './Modal.vue'
+import { api } from '../api/index.js'
+
+const ROLE_LABELS = { leiter: 'Leiter', lernender: 'Lernpartner', mentor: 'Coach' }
+
+const GROUP_LABELS = {
+  projects:     'Projekte',
+  tasks:        'Aufgaben',
+  sprints:      'Sprints',
+  time_entries: 'Zeiteinträge',
+  todos:        'Todos',
+  users:        'Benutzer',
+  mentors:      'Coaches',
+  reports:      'Berichte',
+  settings:     'Einstellungen',
+  werkstatt:    'Werkstatt',
+}
+
+const props = defineProps({
+  modelValue: Boolean,
+  userId:     { type: Number, required: true },
+  userName:   { type: String, required: true },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const loading     = ref(false)
+const saving      = ref(false)
+const roleName    = ref('')
+const permissions = ref([])
+const overrides   = ref({})
+
+const roleLabel = computed(() => ROLE_LABELS[roleName.value] ?? roleName.value)
+
+const groups = computed(() => {
+  const map = {}
+  for (const p of permissions.value) {
+    const prefix = p.key.split('.')[0]
+    if (!map[prefix]) map[prefix] = []
+    map[prefix].push(p)
+  }
+  return Object.entries(map).map(([prefix, perms]) => ({
+    label:       GROUP_LABELS[prefix] ?? prefix,
+    permissions: perms,
+  }))
+})
+
+watch(() => props.modelValue, async (open) => {
+  if (!open) return
+  loading.value = true
+  const data = await api.getUserPermissions(props.userId)
+  roleName.value    = data.role
+  permissions.value = data.permissions
+  overrides.value   = {}
+  for (const p of data.permissions) {
+    if (p.override !== null) overrides.value[p.key] = p.override ? '1' : '0'
+  }
+  loading.value = false
+})
+
+function setOverride(key, value) {
+  if (value === '') {
+    delete overrides.value[key]
+  } else {
+    overrides.value[key] = value
+  }
+}
+
+async function save() {
+  saving.value = true
+  try {
+    const payload = {}
+    for (const [key, val] of Object.entries(overrides.value)) {
+      payload[key] = val === '1'
+    }
+    await api.updateUserPermissions(props.userId, payload)
+    emit('update:modelValue', false)
+  } catch (err) {
+    alert('Fehler beim Speichern: ' + err.message)
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/src/components/UserPermissionsModal.vue
+++ b/src/components/UserPermissionsModal.vue
@@ -124,7 +124,7 @@ watch(() => props.modelValue, async (open) => {
     if (p.override !== null) overrides.value[p.key] = p.override ? '1' : '0'
   }
   loading.value = false
-})
+}, { immediate: true })
 
 function setOverride(key, value) {
   if (value === '') {

--- a/src/composables/useNavLinks.js
+++ b/src/composables/useNavLinks.js
@@ -10,6 +10,7 @@ const ICONS = {
   lernende:     'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z',
   coaches:      'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
   werkstatt:    'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065zM15 12a3 3 0 11-6 0 3 3 0 016 0z',
+  rollen:       'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01',
 }
 
 export function useNavLinks() {
@@ -25,7 +26,8 @@ export function useNavLinks() {
     if (auth.can('sprints.manage')) base.push({ to: '/sprints',      label: 'Sprints',       icon: ICONS.sprints  })
     if (auth.can('users.list'))     base.push({ to: '/lernende',     label: 'Lernpartner',   icon: ICONS.lernende })
     if (auth.can('mentors.manage')) base.push({ to: '/mentoren',     label: 'Coaches',       icon: ICONS.coaches  })
-    if (auth.can('werkstatt.view')) base.push({ to: '/werkstatt',    label: 'Werkstatt',     icon: ICONS.werkstatt})
+    if (auth.can('werkstatt.view'))   base.push({ to: '/werkstatt',  label: 'Werkstatt',       icon: ICONS.werkstatt })
+    if (auth.can('settings.manage')) base.push({ to: '/rollen',     label: 'Berechtigungen',  icon: ICONS.rollen   })
     return base
   })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ const routes = [
   { path: '/mentoren',     name: 'mentors',  component: () => import('../views/MentorsView.vue'),     meta: { permission: 'mentors.manage' } },
   { path: '/werkstatt',   name: 'werkstatt', component: () => import('../views/WerkstattView.vue'),  meta: { permission: 'werkstatt.view' } },
   { path: '/mein-bereich', name: 'my-area',  component: () => import('../views/MyAreaView.vue') },
+  { path: '/rollen',       name: 'roles',    component: () => import('../views/RolesView.vue'),    meta: { permission: 'settings.manage' } },
 ]
 
 const router = createRouter({

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -50,11 +50,22 @@ export const useAuthStore = defineStore('auth', () => {
   const token = ref(localStorage.getItem('token'))
   const user  = ref(JSON.parse(localStorage.getItem('user') ?? 'null'))
 
+  // Effective permissions fetched from API; falls back to role map until loaded
+  const storedPerms = localStorage.getItem('permissions')
+  const permissions = ref(
+    storedPerms ? new Set(JSON.parse(storedPerms)) : ROLE_PERMISSIONS[user.value?.role] ?? new Set()
+  )
+
   const isLoggedIn = computed(() => !!token.value)
   const isLeiter   = computed(() => user.value?.role === 'leiter')
   const isMentor   = computed(() => user.value?.role === 'mentor')
 
-  const can = (permission) => ROLE_PERMISSIONS[user.value?.role]?.has(permission) ?? false
+  const can = (permission) => permissions.value.has(permission)
+
+  function setPermissions(list) {
+    permissions.value = new Set(list)
+    localStorage.setItem('permissions', JSON.stringify(list))
+  }
 
   let refreshTimer = null
 
@@ -68,6 +79,7 @@ export const useAuthStore = defineStore('auth', () => {
           const res = await api.refreshToken()
           token.value = res.token
           localStorage.setItem('token', res.token)
+          if (res.permissions) setPermissions(res.permissions)
         } catch { /* 401 wird von req() behandelt */ }
       }
     }, 5 * 60 * 1000)
@@ -84,6 +96,7 @@ export const useAuthStore = defineStore('auth', () => {
     user.value  = data.user
     localStorage.setItem('token', data.token)
     localStorage.setItem('user', JSON.stringify(data.user))
+    setPermissions(data.permissions ?? [])
     startRefreshInterval()
   }
 
@@ -91,11 +104,17 @@ export const useAuthStore = defineStore('auth', () => {
     stopRefreshInterval()
     token.value = null
     user.value  = null
+    permissions.value = new Set()
     localStorage.removeItem('token')
     localStorage.removeItem('user')
+    localStorage.removeItem('permissions')
   }
 
-  if (token.value) startRefreshInterval()
+  // Hydrate permissions from API on page load (ensures overrides are reflected)
+  if (token.value) {
+    startRefreshInterval()
+    api.getMyPermissions().then(data => setPermissions(data.permissions)).catch(() => {})
+  }
 
   return { token, user, isLoggedIn, isLeiter, isMentor, can, login, logout }
 })

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -16,7 +16,7 @@
         <div v-for="u in activeLearners" :key="u.id" class="card flex flex-col gap-3">
           <LearnerCard :u="u" :auth="auth"
             @triggerUpload="triggerUpload" @removeAvatar="removeAvatar"
-            @sendReset="sendReset" @edit="openEdit" @remove="remove"
+            @sendReset="sendReset" @edit="openEdit" @editPermissions="openPermissions" @remove="remove"
             @toggleActive="handleToggleActive" />
         </div>
         <div v-if="!activeLearners.length" class="col-span-3 text-center py-12 text-lo italic">
@@ -41,6 +41,9 @@
     <input ref="fileInput" type="file" accept="image/jpeg,image/png,image/webp"
            class="hidden" @change="onFileSelected" />
 
+    <UserPermissionsModal v-if="permTarget" v-model="showPermModal"
+      :user-id="permTarget.id" :user-name="permTarget.name" />
+
     <Modal v-model="showModal" :title="editing ? 'Lernpartner bearbeiten' : 'Lernpartner anlegen'">
       <UserForm :user="editing" :loading="saving" @submit="save" @cancel="showModal = false" />
       <p v-if="!editing" class="mt-3 text-xs text-lo">
@@ -58,12 +61,15 @@ import { api } from '../api/index.js'
 import Modal from '../components/Modal.vue'
 import UserForm from '../components/UserForm.vue'
 import LearnerCard from '../components/LearnerCard.vue'
+import UserPermissionsModal from '../components/UserPermissionsModal.vue'
 
 const auth      = useAuthStore()
 const users     = useUsersStore()
 const showModal = ref(false)
 const editing   = ref(null)
 const saving    = ref(false)
+const permTarget    = ref(null)
+const showPermModal = ref(false)
 const fileInput = ref(null)
 const uploading = ref(null)
 
@@ -72,8 +78,9 @@ const inactiveLearners = computed(() => users.list.filter(u => u.role === 'lerne
 
 onMounted(() => users.fetchAll())
 
-function openCreate() { editing.value = null; showModal.value = true }
-function openEdit(u)  { editing.value = u;    showModal.value = true }
+function openCreate()      { editing.value = null; showModal.value = true }
+function openEdit(u)       { editing.value = u;    showModal.value = true }
+function openPermissions(u){ permTarget.value = u; showPermModal.value = true }
 
 function triggerUpload(u) {
   uploading.value = u

--- a/src/views/MentorsView.vue
+++ b/src/views/MentorsView.vue
@@ -50,6 +50,7 @@
             Reset-E-Mail
           </button>
           <button class="btn btn-sm btn-secondary" @click="openEdit(m)">Bearbeiten</button>
+          <button class="btn btn-sm btn-secondary" @click="openPermissions(m)" title="Berechtigungen anpassen">Berechtigungen</button>
           <button class="btn btn-sm btn-danger" @click="remove(m)">Löschen</button>
         </div>
       </div>
@@ -58,6 +59,9 @@
         Noch keine Coaches erfasst.
       </div>
     </div>
+
+    <UserPermissionsModal v-if="permTarget" v-model="showPermModal"
+      :user-id="permTarget.id" :user-name="permTarget.name" />
 
     <Modal v-model="showModal" :title="editing ? 'Coach bearbeiten' : 'Coach anlegen'">
       <MentorForm :mentor="editing" :loading="saving" @submit="save" @cancel="showModal = false" />
@@ -72,6 +76,7 @@ import { useUsersStore } from '../stores/users.js'
 import Modal from '../components/Modal.vue'
 import UserAvatar from '../components/UserAvatar.vue'
 import MentorForm from '../components/MentorForm.vue'
+import UserPermissionsModal from '../components/UserPermissionsModal.vue'
 
 const usersStore = useUsersStore()
 
@@ -79,9 +84,11 @@ const loading     = ref(false)
 const mentors     = ref([])
 const assignments = reactive({})
 const assignTarget = reactive({})
-const showModal   = ref(false)
-const editing     = ref(null)
-const saving      = ref(false)
+const showModal     = ref(false)
+const editing       = ref(null)
+const saving        = ref(false)
+const permTarget    = ref(null)
+const showPermModal = ref(false)
 
 const learners = computed(() => usersStore.list.filter(u => u.role === 'lernender' && u.active))
 
@@ -104,8 +111,9 @@ async function fetchMentors() {
 
 onMounted(() => { fetchMentors(); usersStore.fetchAll() })
 
-function openCreate() { editing.value = null; showModal.value = true }
-function openEdit(m)  { editing.value = m;    showModal.value = true }
+function openCreate()      { editing.value = null; showModal.value = true }
+function openEdit(m)       { editing.value = m;    showModal.value = true }
+function openPermissions(m){ permTarget.value = m; showPermModal.value = true }
 
 async function save(body) {
   saving.value = true

--- a/src/views/RolesView.vue
+++ b/src/views/RolesView.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="max-w-5xl mx-auto px-4 py-8 space-y-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold text-hi">Rollenverwaltung</h1>
+    </div>
+
+    <p class="text-sm text-lo">
+      Änderungen gelten sofort für alle API-Zugriffe. Frontend-Sichtbarkeit (Buttons, Nav-Einträge)
+      wird erst nach erneutem Anmelden aktualisiert.
+    </p>
+
+    <div v-if="loading" class="text-lo italic text-center py-12">Laden…</div>
+
+    <div v-else class="card overflow-x-auto p-0">
+      <table class="min-w-full text-sm">
+        <thead class="bg-lift border-b border-groove">
+          <tr>
+            <th class="px-4 py-3 text-left font-medium text-mid w-full">Berechtigung</th>
+            <th v-for="role in roles" :key="role"
+                class="px-6 py-3 text-center font-semibold text-hi whitespace-nowrap capitalize min-w-[110px]">
+              {{ ROLE_LABELS[role] }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <template v-for="group in groups" :key="group.label">
+            <tr class="bg-brand-subtle/40">
+              <td :colspan="roles.length + 1"
+                  class="px-4 py-1.5 text-xs font-semibold text-brand-700 uppercase tracking-wide">
+                {{ group.label }}
+              </td>
+            </tr>
+            <tr v-for="perm in group.permissions" :key="perm.key"
+                class="border-t border-groove hover:bg-lift transition-colors">
+              <td class="px-4 py-2.5">
+                <span class="font-mono text-xs text-mid">{{ perm.key }}</span>
+                <span class="text-lo text-xs ml-2">{{ perm.description }}</span>
+              </td>
+              <td v-for="role in roles" :key="role" class="px-6 py-2.5 text-center">
+                <input
+                  type="checkbox"
+                  :checked="perm.grants.includes(role)"
+                  :disabled="saving[role]"
+                  class="rounded border-line text-brand-600 focus:ring-brand-500 cursor-pointer"
+                  @change="toggle(role, perm.key, $event.target.checked)"
+                />
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { api } from '../api/index.js'
+
+const ROLE_LABELS = {
+  leiter:    'Leiter',
+  lernender: 'Lernpartner',
+  mentor:    'Coach',
+}
+
+const GROUP_LABELS = {
+  projects:     'Projekte',
+  tasks:        'Aufgaben',
+  sprints:      'Sprints',
+  time_entries: 'Zeiteinträge',
+  todos:        'Todos',
+  users:        'Benutzer',
+  mentors:      'Coaches',
+  reports:      'Berichte',
+  settings:     'Einstellungen',
+  werkstatt:    'Werkstatt',
+}
+
+const loading     = ref(true)
+const roles       = ref([])
+const permissions = ref([])
+const saving      = ref({})
+
+const groups = computed(() => {
+  const map = {}
+  for (const p of permissions.value) {
+    const prefix = p.key.split('.')[0]
+    if (!map[prefix]) map[prefix] = []
+    map[prefix].push(p)
+  }
+  return Object.entries(map).map(([prefix, perms]) => ({
+    label:       GROUP_LABELS[prefix] ?? prefix,
+    permissions: perms,
+  }))
+})
+
+onMounted(async () => {
+  const data  = await api.getRoles()
+  roles.value = data.roles
+  permissions.value = data.permissions
+  roles.value.forEach(r => (saving.value[r] = false))
+  loading.value = false
+})
+
+async function toggle(role, key, granted) {
+  const perm = permissions.value.find(p => p.key === key)
+  if (!perm) return
+
+  // Optimistic update
+  if (granted) {
+    perm.grants.push(role)
+  } else {
+    perm.grants = perm.grants.filter(r => r !== role)
+  }
+
+  saving.value[role] = true
+  try {
+    const current = permissions.value
+      .filter(p => p.grants.includes(role))
+      .map(p => p.key)
+    await api.updateRolePermissions(role, current)
+  } catch (err) {
+    // Roll back on error
+    if (granted) {
+      perm.grants = perm.grants.filter(r => r !== role)
+    } else {
+      perm.grants.push(role)
+    }
+    alert('Fehler beim Speichern: ' + err.message)
+  } finally {
+    saving.value[role] = false
+  }
+}
+</script>


### PR DESCRIPTION
## Summary

- `auth.can()` now uses server-fetched permissions instead of a hardcoded map
- New `/rollen` view (leiter-only): permission matrix for managing roles
- New `UserPermissionsModal`: per-user permission overrides (Phase 5)
- Fix: permissions are loaded on first open of `UserPermissionsModal`

## Depends on

Requires matching backend PR in `abteilung-webit-api`.

## Test plan

- [ ] `auth.can()` reflects server-side permissions correctly
- [ ] `/rollen` accessible as leiter, redirected otherwise
- [ ] Role permission matrix saves changes correctly
- [ ] Per-user overrides modal opens and saves overrides
- [ ] Permissions load correctly on first modal open (not just subsequent ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)