### PR TITLE
feat: Vue toast notifications — replace all JS alerts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,8 @@
         </main>
       </div>
 
+      <ToastContainer />
+
       <!-- Mobile bottom nav -->
       <nav class="sm:hidden flex shrink-0 bg-black dark:bg-zinc-950 border-t border-white/10">
         <RouterLink
@@ -39,6 +41,7 @@ import { useRoute } from 'vue-router'
 import TopBar from './components/TopBar.vue'
 import SideBar from './components/SideBar.vue'
 import Footer from './components/Footer.vue'
+import ToastContainer from './components/ToastContainer.vue'
 import { useAuthStore } from './stores/auth.js'
 import { useNavLinks } from './composables/useNavLinks.js'
 

--- a/src/components/ProjectPermissionsPanel.vue
+++ b/src/components/ProjectPermissionsPanel.vue
@@ -52,6 +52,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useToast } from '../composables/useToast.js'
 import { api } from '../api/index.js'
 
 const PERM_GROUPS = {
@@ -75,6 +76,7 @@ const props = defineProps({
 const loading    = ref(false)
 const saving     = ref(false)
 const grants     = ref([])
+const { toastError } = useToast()
 const allPerms   = ref([])
 const form       = ref({ userId: '', permission: '' })
 
@@ -119,7 +121,7 @@ async function addPermission() {
     form.value.permission = ''
     await load()
   } catch (err) {
-    alert(err.message)
+    toastError(err.message)
   } finally {
     saving.value = false
   }

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -1,0 +1,32 @@
+<template>
+  <Teleport to="body">
+    <div class="fixed bottom-6 right-6 z-50 flex flex-col gap-2 items-end pointer-events-none">
+      <TransitionGroup name="toast">
+        <div
+          v-for="t in toasts"
+          :key="t.id"
+          :class="[
+            'pointer-events-auto flex items-start gap-3 px-4 py-3 rounded-lg shadow-lg text-sm max-w-sm',
+            t.type === 'success' ? 'bg-emerald-900/90 text-emerald-100 ring-1 ring-emerald-700' :
+            t.type === 'info'    ? 'bg-surface text-hi ring-1 ring-line' :
+                                   'bg-red-900/90 text-red-100 ring-1 ring-red-700'
+          ]">
+          <span class="flex-1">{{ t.message }}</span>
+          <button class="opacity-60 hover:opacity-100 leading-none" @click="remove(t.id)">✕</button>
+        </div>
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { useToast } from '../composables/useToast.js'
+const { toasts, remove } = useToast()
+</script>
+
+<style scoped>
+.toast-enter-active,
+.toast-leave-active { transition: all 0.25s ease; }
+.toast-enter-from  { opacity: 0; transform: translateY(8px); }
+.toast-leave-to    { opacity: 0; transform: translateY(8px); }
+</style>

--- a/src/components/UserPermissionsModal.vue
+++ b/src/components/UserPermissionsModal.vue
@@ -67,6 +67,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { useToast } from '../composables/useToast.js'
 import Modal from './Modal.vue'
 import { api } from '../api/index.js'
 
@@ -94,6 +95,7 @@ const emit = defineEmits(['update:modelValue'])
 
 const loading     = ref(false)
 const saving      = ref(false)
+const { toastError } = useToast()
 const roleName    = ref('')
 const permissions = ref([])
 const overrides   = ref({})
@@ -144,7 +146,7 @@ async function save() {
     await api.updateUserPermissions(props.userId, payload)
     emit('update:modelValue', false)
   } catch (err) {
-    alert('Fehler beim Speichern: ' + err.message)
+    toastError('Fehler beim Speichern: ' + err.message)
   } finally {
     saving.value = false
   }

--- a/src/composables/useToast.js
+++ b/src/composables/useToast.js
@@ -1,0 +1,24 @@
+import { ref } from 'vue'
+
+const toasts = ref([])
+let nextId = 0
+
+function add(message, type = 'error', duration = 4000) {
+  const id = ++nextId
+  toasts.value.push({ id, message, type })
+  setTimeout(() => remove(id), duration)
+}
+
+function remove(id) {
+  toasts.value = toasts.value.filter(t => t.id !== id)
+}
+
+export function useToast() {
+  return {
+    toasts,
+    toast:        (msg, duration) => add(msg, 'info', duration),
+    toastSuccess: (msg, duration) => add(msg, 'success', duration),
+    toastError:   (msg, duration) => add(msg, 'error', duration),
+    remove,
+  }
+}

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -55,6 +55,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useToast } from '../composables/useToast.js'
 import { useAuthStore } from '../stores/auth.js'
 import { useUsersStore } from '../stores/users.js'
 import { api } from '../api/index.js'
@@ -63,8 +64,9 @@ import UserForm from '../components/UserForm.vue'
 import LearnerCard from '../components/LearnerCard.vue'
 import UserPermissionsModal from '../components/UserPermissionsModal.vue'
 
-const auth      = useAuthStore()
-const users     = useUsersStore()
+const auth              = useAuthStore()
+const users             = useUsersStore()
+const { toastSuccess, toastError } = useToast()
 const showModal = ref(false)
 const editing   = ref(null)
 const saving    = ref(false)
@@ -95,7 +97,7 @@ async function onFileSelected(e) {
     await api.uploadAvatar(uploading.value.id, file)
     await users.fetchAll()
   } catch (err) {
-    alert(err.message)
+    toastError(err.message)
   } finally {
     uploading.value = null
   }
@@ -120,9 +122,9 @@ async function sendReset(u) {
   if (!confirm(`Passwort-Reset-E-Mail an „${u.name}" (${u.email}) senden?`)) return
   try {
     await api.sendResetEmail(u.id)
-    alert(`Reset-E-Mail an ${u.email} gesendet.`)
+    toastSuccess(`Reset-E-Mail an ${u.email} gesendet.`)
   } catch (err) {
-    alert(err.message)
+    toastError(err.message)
   }
 }
 

--- a/src/views/MentorsView.vue
+++ b/src/views/MentorsView.vue
@@ -71,6 +71,7 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
+import { useToast } from '../composables/useToast.js'
 import { api } from '../api/index.js'
 import { useUsersStore } from '../stores/users.js'
 import Modal from '../components/Modal.vue'
@@ -79,6 +80,7 @@ import MentorForm from '../components/MentorForm.vue'
 import UserPermissionsModal from '../components/UserPermissionsModal.vue'
 
 const usersStore = useUsersStore()
+const { toastSuccess, toastError } = useToast()
 
 const loading     = ref(false)
 const mentors     = ref([])
@@ -143,9 +145,9 @@ async function sendReset(m) {
   if (!confirm(`Passwort-Reset-E-Mail an „${m.name}" (${m.email}) senden?`)) return
   try {
     await api.sendResetEmail(m.id)
-    alert(`Reset-E-Mail an ${m.email} gesendet.`)
+    toastSuccess(`Reset-E-Mail an ${m.email} gesendet.`)
   } catch (err) {
-    alert(err.message)
+    toastError(err.message)
   }
 }
 

--- a/src/views/RolesView.vue
+++ b/src/views/RolesView.vue
@@ -80,6 +80,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { useToast } from '../composables/useToast.js'
 import { api } from '../api/index.js'
 import { useProjectsStore } from '../stores/projects.js'
 import { useUsersStore } from '../stores/users.js'
@@ -106,6 +107,7 @@ const GROUP_LABELS = {
 
 const projectsStore = useProjectsStore()
 const usersStore    = useUsersStore()
+const { toastError } = useToast()
 
 const loading          = ref(true)
 const roles            = ref([])
@@ -164,7 +166,7 @@ async function toggle(role, key, granted) {
     } else {
       perm.grants.push(role)
     }
-    alert('Fehler beim Speichern: ' + err.message)
+    toastError('Fehler beim Speichern: ' + err.message)
   } finally {
     saving.value[role] = false
   }


### PR DESCRIPTION
## Summary

- New `useToast` composable: module-singleton toast queue (`toast`, `toastSuccess`, `toastError`)
- New `ToastContainer` component: fixed bottom-right, animated with `TransitionGroup`, auto-dismisses after 4 s, manual ✕ close
- Mounted in `App.vue` via `<Teleport to="body">`
- Replaced all 8 `alert()` call sites across `LearnersView`, `MentorsView`, `RolesView`, `ProjectPermissionsPanel`, `UserPermissionsModal`

Closes #61

## Test plan

- [ ] Trigger a save error → red toast appears bottom-right, dismisses after 4 s
- [ ] Send password-reset email → green success toast
- [ ] ✕ button closes toast immediately
- [ ] Multiple toasts stack without overlap
- [ ] No more browser alert dialogs anywhere in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)