### PR TITLE
feat: inline ConfirmButton replaces all window.confirm dialogs + Swiss quotes

### DIFF
--- a/src/components/ConfirmButton.vue
+++ b/src/components/ConfirmButton.vue
@@ -1,0 +1,40 @@
+<template>
+  <span class="inline-flex items-center gap-1">
+    <template v-if="pending">
+      <span class="text-xs text-mid whitespace-nowrap">{{ label }}</span>
+      <button type="button" class="btn btn-xs btn-danger" @click.stop="confirm">✓</button>
+      <button type="button" class="btn btn-xs btn-secondary" @click.stop="reset">✕</button>
+    </template>
+    <button v-else type="button" v-bind="$attrs" @click.stop="ask">
+      <slot />
+    </button>
+  </span>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  label: { type: String, default: 'Wirklich?' },
+  timeout: { type: Number, default: 3000 },
+})
+const emit = defineEmits(['confirm'])
+
+const pending = ref(false)
+let timer = null
+
+function ask() {
+  pending.value = true
+  timer = setTimeout(reset, props.timeout)
+}
+
+function confirm() {
+  reset()
+  emit('confirm')
+}
+
+function reset() {
+  clearTimeout(timer)
+  pending.value = false
+}
+</script>

--- a/src/components/KanbanCard.vue
+++ b/src/components/KanbanCard.vue
@@ -23,12 +23,12 @@
               d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
           </svg>
         </button>
-        <button @click.stop="$emit('delete', task.id)"
-                class="text-lo hover:text-red-500 transition-colors">
+        <ConfirmButton :label="`«${task.title}» wirklich löschen?`" @confirm="$emit('delete', task.id)"
+                       class="text-lo hover:text-red-500 transition-colors">
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
           </svg>
-        </button>
+        </ConfirmButton>
       </div>
     </div>
 
@@ -75,6 +75,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import ConfirmButton from './ConfirmButton.vue'
 import UserAvatar from './UserAvatar.vue'
 import MarkdownRenderer from './MarkdownRenderer.vue'
 

--- a/src/components/LearnerCard.vue
+++ b/src/components/LearnerCard.vue
@@ -20,10 +20,12 @@
       <div class="flex-1 min-w-0">
         <p class="font-semibold text-hi">{{ u.name }}</p>
         <p class="text-xs text-lo mt-0.5">{{ u.email || u.username }}</p>
-        <button v-if="auth.can('users.update') && u.avatar && u.active" @click.stop="$emit('removeAvatar', u)"
-                class="text-xs text-red-500 hover:underline mt-0.5">
+        <ConfirmButton v-if="auth.can('users.update') && u.avatar && u.active"
+                       label="Foto wirklich entfernen?"
+                       @confirm="$emit('removeAvatar', u)"
+                       class="text-xs text-red-500 hover:underline mt-0.5">
           Foto entfernen
-        </button>
+        </ConfirmButton>
       </div>
     </div>
 
@@ -35,7 +37,7 @@
       </button>
       <button v-if="u.active" class="btn btn-sm btn-secondary" @click="$emit('edit', u)">Bearbeiten</button>
       <button v-if="u.active" class="btn btn-sm btn-secondary" @click="$emit('editPermissions', u)" title="Berechtigungen anpassen">Berechtigungen</button>
-      <button v-if="u.active" class="btn btn-sm btn-danger" @click="$emit('remove', u)">Löschen</button>
+      <ConfirmButton v-if="u.active" class="btn btn-sm btn-danger" :label="`«${u.name}» wirklich löschen?`" @confirm="$emit('remove', u)">Löschen</ConfirmButton>
       <label class="flex items-center gap-1.5 text-sm text-mid cursor-pointer ml-auto select-none">
         <input type="checkbox" :checked="!!u.active"
                class="rounded border-line text-brand-600"
@@ -48,6 +50,7 @@
 
 <script setup>
 import UserAvatar from './UserAvatar.vue'
+import ConfirmButton from './ConfirmButton.vue'
 
 defineProps({
   u:    { type: Object, required: true },

--- a/src/components/SprintPanel.vue
+++ b/src/components/SprintPanel.vue
@@ -43,11 +43,11 @@
                     d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                 </svg>
               </button>
-              <button @click="removeSprint(sprint.id)" class="text-lo hover:text-red-500 transition-colors">
+              <ConfirmButton label="Sprint löschen? Aufgaben bleiben erhalten." @confirm="removeSprint(sprint.id)" class="text-lo hover:text-red-500 transition-colors">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                 </svg>
-              </button>
+              </ConfirmButton>
             </template>
           </div>
         </div>
@@ -107,6 +107,7 @@
 import { ref, computed } from 'vue'
 import { useSprintsStore } from '../stores/sprints.js'
 import { useAuthStore } from '../stores/auth.js'
+import ConfirmButton from './ConfirmButton.vue'
 import Modal from './Modal.vue'
 import MarkdownRenderer from './MarkdownRenderer.vue'
 
@@ -203,7 +204,6 @@ async function save() {
 }
 
 async function removeSprint(id) {
-  if (!confirm('Sprint wirklich löschen? Aufgaben bleiben erhalten.')) return
   await sprints.remove(id)
 }
 

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -52,11 +52,11 @@
                 d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
             </svg>
           </button>
-          <button @click="remove(todo.id)" class="text-lo hover:text-red-500 p-1 rounded">
+          <ConfirmButton label="Todo wirklich löschen?" @confirm="remove(todo.id)" class="text-lo hover:text-red-500 p-1 rounded">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
             </svg>
-          </button>
+          </ConfirmButton>
         </div>
       </li>
     </ul>
@@ -99,6 +99,7 @@
 import { ref, computed } from 'vue'
 import { useTodosStore } from '../stores/todos.js'
 import { useAuthStore } from '../stores/auth.js'
+import ConfirmButton from './ConfirmButton.vue'
 import Modal from './Modal.vue'
 import MarkdownRenderer from './MarkdownRenderer.vue'
 
@@ -169,7 +170,6 @@ async function toggleDone(todo) {
 }
 
 async function remove(id) {
-  if (!confirm('Todo wirklich löschen?')) return
   await todos.remove(id)
 }
 </script>

--- a/src/style.css
+++ b/src/style.css
@@ -51,6 +51,9 @@
   .btn-sm {
     @apply px-2.5 py-1 text-xs;
   }
+  .btn-xs {
+    @apply px-1.5 py-0.5 text-xs rounded-md;
+  }
   .card {
     @apply bg-surface rounded-xl shadow-sm ring-1 ring-line p-5;
   }

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -104,7 +104,6 @@ async function onFileSelected(e) {
 }
 
 async function removeAvatar(u) {
-  if (!confirm(`Foto von „${u.name}" entfernen?`)) return
   await api.deleteAvatar(u.id)
   await users.fetchAll()
 }
@@ -129,11 +128,10 @@ async function sendReset(u) {
 
 async function handleToggleActive(u, active) {
   await users.toggleActive(u.id, active)
-  toast(active ? `„${u.name}" wurde aktiviert.` : `„${u.name}" wurde deaktiviert.`)
+  toast(active ? `«${u.name}» wurde aktiviert.` : `«${u.name}» wurde deaktiviert.`)
 }
 
 async function remove(u) {
-  if (!confirm(`„${u.name}" und alle zugehörigen Daten löschen?`)) return
   await users.remove(u.id)
 }
 </script>

--- a/src/views/MentorsView.vue
+++ b/src/views/MentorsView.vue
@@ -29,7 +29,7 @@
             <span v-for="l in assignments[m.id]" :key="l.id"
                   class="inline-flex items-center gap-1 text-xs bg-brand-subtle text-brand-700 rounded-full px-2 py-0.5">
               {{ l.name }}
-              <button @click="unassign(m, l)" class="hover:text-red-500 transition-colors" title="Zuweisung aufheben">×</button>
+              <ConfirmButton :label="`Zuweisung von «${l.name}» aufheben?`" @confirm="unassign(m, l)" class="hover:text-red-500 transition-colors" title="Zuweisung aufheben">×</ConfirmButton>
             </span>
           </div>
         </div>
@@ -51,7 +51,7 @@
           </button>
           <button class="btn btn-sm btn-secondary" @click="openEdit(m)">Bearbeiten</button>
           <button class="btn btn-sm btn-secondary" @click="openPermissions(m)" title="Berechtigungen anpassen">Berechtigungen</button>
-          <button class="btn btn-sm btn-danger" @click="remove(m)">Löschen</button>
+          <ConfirmButton class="btn btn-sm btn-danger" :label="`Coach «${m.name}» wirklich löschen?`" @confirm="remove(m)">Löschen</ConfirmButton>
         </div>
       </div>
 
@@ -72,6 +72,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
 import { useToast } from '../composables/useToast.js'
+import ConfirmButton from '../components/ConfirmButton.vue'
 import { api } from '../api/index.js'
 import { useUsersStore } from '../stores/users.js'
 import Modal from '../components/Modal.vue'
@@ -128,7 +129,6 @@ async function save(body) {
 }
 
 async function remove(m) {
-  if (!confirm(`Coach „${m.name}" wirklich löschen?`)) return
   await api.deleteMentor(m.id)
   await fetchMentors()
 }
@@ -151,7 +151,6 @@ async function sendReset(m) {
 }
 
 async function unassign(mentor, learner) {
-  if (!confirm(`Zuweisung von „${learner.name}" zu „${mentor.name}" aufheben?`)) return
   await api.unassignLernender(mentor.id, learner.id)
   assignments[mentor.id] = await api.getMentorLernende(mentor.id)
 }

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -283,7 +283,6 @@ async function saveTask() {
 async function moveTask(id, status) { await tasks.move(id, status) }
 
 async function deleteTask(id) {
-  if (!confirm('Aufgabe wirklich löschen?')) return
   await tasks.remove(id)
 }
 

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -64,7 +64,7 @@
             <span class="text-xs text-lo">{{ p.owner_name }}</span>
             <div v-if="canEditProject(p)" class="flex gap-1" @click.stop>
               <button class="btn btn-sm btn-secondary" @click="openEdit(p)">Bearbeiten</button>
-              <button class="btn btn-sm btn-danger" @click="confirmDelete(p)">Löschen</button>
+              <ConfirmButton class="btn btn-sm btn-danger" :label="`Projekt «${p.name}» wirklich löschen?`" @confirm="confirmDelete(p)">Löschen</ConfirmButton>
             </div>
           </div>
         </div>
@@ -84,11 +84,11 @@
           <p v-if="t.description" class="text-sm text-mid line-clamp-2">{{ markdownPreview(t.description) }}</p>
           <div class="flex justify-end gap-1 mt-auto pt-2 border-t border-groove" @click.stop>
             <button class="btn btn-sm btn-secondary" @click="openEdit(t)">Bearbeiten</button>
-            <button class="btn btn-sm btn-danger" @click="confirmDelete(t)">Löschen</button>
+            <ConfirmButton class="btn btn-sm btn-danger" :label="`Vorlage «${t.name}» wirklich löschen?`" @confirm="confirmDelete(t)">Löschen</ConfirmButton>
           </div>
         </div>
         <div v-if="!projects.templates.length" class="col-span-full text-center py-12 text-lo italic">
-          Noch keine Vorlagen. Erstelle ein Projekt und aktiviere „Als Vorlage speichern".
+          Noch keine Vorlagen. Erstelle ein Projekt und aktiviere «Als Vorlage speichern».
         </div>
       </div>
     </template>
@@ -113,6 +113,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useProjectsStore } from '../stores/projects.js'
 import { useUsersStore } from '../stores/users.js'
+import ConfirmButton from '../components/ConfirmButton.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import Modal from '../components/Modal.vue'
 import ProjectForm from '../components/ProjectForm.vue'
@@ -198,8 +199,6 @@ async function save(body) {
 }
 
 async function confirmDelete(p) {
-  const label = p.is_template ? 'Vorlage' : 'Projekt'
-  if (!confirm(`${label} „${p.name}" wirklich löschen?`)) return
   await projects.remove(p.id)
   if (p.is_template) await projects.fetchTemplates()
 }

--- a/src/views/TimeEntryView.vue
+++ b/src/views/TimeEntryView.vue
@@ -79,7 +79,7 @@
             <td class="px-4 py-3 flex gap-1 justify-end">
               <template v-if="canEdit(e)">
                 <button class="btn btn-sm btn-secondary" @click="openEdit(e)">Bearbeiten</button>
-                <button class="btn btn-sm btn-danger" @click="remove(e.id)">Löschen</button>
+                <ConfirmButton class="btn btn-sm btn-danger" label="Eintrag wirklich löschen?" @confirm="remove(e.id)">Löschen</ConfirmButton>
               </template>
             </td>
           </tr>
@@ -104,6 +104,7 @@ import { useProjectsStore } from '../stores/projects.js'
 import { useUsersStore } from '../stores/users.js'
 import { useTimeEntriesStore } from '../stores/timeEntries.js'
 import { useSprintsStore } from '../stores/sprints.js'
+import ConfirmButton from '../components/ConfirmButton.vue'
 import Modal from '../components/Modal.vue'
 import TimeEntryForm from '../components/TimeEntryForm.vue'
 
@@ -162,7 +163,6 @@ async function save(body) {
 }
 
 async function remove(id) {
-  if (!confirm('Eintrag wirklich löschen?')) return
   await timeStore.remove(id)
 }
 


### PR DESCRIPTION
## Summary

- New `ConfirmButton` component: first click shows an inline «Wirklich?» state with ✓ / ✕ buttons; auto-resets after 3 s; accepts any button class via `$attrs`
- Added `btn-xs` utility class to `style.css`
- Replaced all 9 remaining `window.confirm()` call sites across 8 files — the JS guard lines were removed, confirmation is now fully UI-driven
- Replaced German `„"` quotes with Swiss `«»` in all user-facing strings

Closes #63

## Files changed

| File | Change |
|---|---|
| `ConfirmButton.vue` | New component |
| `style.css` | `btn-xs` added |
| `LearnerCard.vue` | Löschen + Foto entfernen |
| `KanbanCard.vue` | Aufgabe löschen |
| `TodoList.vue` | Todo löschen |
| `SprintPanel.vue` | Sprint löschen |
| `LearnersView.vue` | removeAvatar + remove guards removed |
| `MentorsView.vue` | Löschen + Zuweisung aufheben |
| `ProjectsView.vue` | Projekt/Vorlage löschen + «» in template text |
| `ProjectDetailView.vue` | deleteTask guard removed |
| `TimeEntryView.vue` | Eintrag löschen |

## Test plan

- [ ] Click a delete button → shows «Wirklich? ✓ ✕» inline
- [ ] ✓ confirms and fires the action
- [ ] ✕ cancels without action
- [ ] Waiting 3 s resets automatically
- [ ] Icon-only buttons (KanbanCard ×, TodoList trash, SprintPanel ×) show the confirm state correctly
- [ ] No browser confirm() dialogs anywhere in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)