### PR TITLE
feat: TodoList als unterer Sidebar-Abschnitt

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside :class="['hidden sm:flex flex-col bg-black dark:bg-zinc-950 text-white shrink-0 transition-[width] duration-200 overflow-hidden', expanded ? 'w-52' : 'w-14']">
+  <aside :class="['hidden sm:flex flex-col bg-black dark:bg-zinc-950 text-white shrink-0 transition-[width] duration-200 overflow-hidden', sidebarWidth]">
     <nav class="flex-1 py-3 flex flex-col gap-0.5 px-2 overflow-y-auto overflow-x-hidden">
       <RouterLink
         v-for="link in links"
@@ -19,6 +19,10 @@
       </RouterLink>
     </nav>
 
+    <div v-if="expanded && isProjectRoute" class="border-t border-white/10 overflow-y-auto p-3 max-h-[50vh]">
+      <TodoList />
+    </div>
+
     <button
       @click="toggleExpanded"
       :title="expanded ? 'Einklappen' : 'Ausklappen'"
@@ -32,14 +36,20 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useNavLinks } from '../composables/useNavLinks.js'
+import TodoList from './TodoList.vue'
 
 const route = useRoute()
 const { links } = useNavLinks()
 
 const expanded = ref(localStorage.getItem('sidebar-expanded') !== 'false')
+const isProjectRoute = computed(() => route.name === 'project')
+const sidebarWidth = computed(() => {
+  if (!expanded.value) return 'w-14'
+  return isProjectRoute.value ? 'w-72' : 'w-52'
+})
 
 function toggleExpanded() {
   expanded.value = !expanded.value

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -45,14 +45,9 @@
         </button>
       </div>
 
-      <div class="flex flex-col xl:flex-row gap-6 max-w-7xl mx-auto">
-        <div class="flex-1 min-w-0">
-          <KanbanBoard :tasks="filteredTasks" :readonly="!auth.can('tasks.create')"
-                       @move="moveTask" @add="addTask" @duplicate="duplicateTask" @edit="openEditTask" @delete="deleteTask" />
-        </div>
-        <div class="xl:w-60 shrink-0">
-          <TodoList />
-        </div>
+      <div class="max-w-7xl mx-auto">
+        <KanbanBoard :tasks="filteredTasks" :readonly="!auth.can('tasks.create')"
+                     @move="moveTask" @add="addTask" @duplicate="duplicateTask" @edit="openEditTask" @delete="deleteTask" />
       </div>
 
       <div v-if="auth.can('projects.manage_members') && projects.current.members?.length" class="mt-6 max-w-7xl mx-auto">
@@ -175,7 +170,6 @@ import KanbanBoard from '../components/KanbanBoard.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import Modal from '../components/Modal.vue'
 import ProjectForm from '../components/ProjectForm.vue'
-import TodoList from '../components/TodoList.vue'
 import MarkdownRenderer from '../components/MarkdownRenderer.vue'
 import ProjectPermissionsPanel from '../components/ProjectPermissionsPanel.vue'
 


### PR DESCRIPTION
## Summary

- `SideBar.vue`: shows `TodoList` below the nav when expanded on `/projekte/:id`; sidebar widens to `w-72` on project routes to accommodate the content (scrollable, `max-h-[50vh]`)
- `ProjectDetailView.vue`: removed the right-side `TodoList` wrapper and the `xl:flex-row` Kanban layout — Kanban now takes the full width

Closes #49

## Test plan

- [ ] On `/projekte/:id` with sidebar expanded → TodoList appears in the lower sidebar
- [ ] On `/projekte/:id` with sidebar collapsed → no TodoList section visible
- [ ] Navigating away from `/projekte/:id` → TodoList section disappears
- [ ] TodoList add/edit/delete/check functions work from the sidebar
- [ ] Kanban board spans full content width without the right column

🤖 Generated with [Claude Code](https://claude.com/claude-code)