### PR TITLE
feat: notification bell — grouped event feed in TopBar

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -97,4 +97,5 @@ export const api = {
   deleteProjectPermissions: (id, userId)           => req(`/projects/${id}/permissions/${userId}`, { method: 'DELETE' }),
   getRoles: ()                     => req('/roles'),
   updateRolePermissions: (role, permissions) => req(`/roles/${role}/permissions`, { method: 'PUT', body: JSON.stringify({ permissions }) }),
+  getNotifications: ()             => req('/notifications'),
 }

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="relative" ref="root">
+    <button
+      @click="toggle"
+      class="relative p-1.5 rounded-md text-neutral-400 hover:text-white hover:bg-white/10 transition-colors"
+      title="Benachrichtigungen">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/>
+      </svg>
+      <span v-if="notifications.unseenCount"
+            class="absolute -top-0.5 -right-0.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none">
+        {{ notifications.unseenCount > 99 ? '99+' : notifications.unseenCount }}
+      </span>
+    </button>
+
+    <Teleport to="body">
+      <div v-if="open"
+           class="fixed z-50 bg-surface ring-1 ring-line shadow-xl rounded-xl w-80 max-h-[70vh] flex flex-col overflow-hidden"
+           :style="panelStyle">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-groove shrink-0">
+          <span class="text-sm font-semibold text-hi">Benachrichtigungen</span>
+          <span v-if="notifications.loading" class="text-xs text-lo">Laden…</span>
+        </div>
+
+        <ul v-if="notifications.list.length" class="overflow-y-auto divide-y divide-groove">
+          <li v-for="n in notifications.list" :key="n.correlation_id ?? n.created_at"
+              class="px-4 py-3 hover:bg-lift transition-colors">
+            <p class="text-sm text-hi font-medium leading-snug">{{ n.subject }}</p>
+            <div class="flex items-center gap-2 mt-1">
+              <span class="text-xs text-lo">{{ formatDate(n.created_at) }}</span>
+              <span v-if="n.recipient_count > 1" class="text-xs text-lo">· {{ n.recipient_count }} Empfänger</span>
+            </div>
+          </li>
+        </ul>
+        <div v-else class="px-4 py-8 text-center text-sm text-lo italic">
+          Keine Benachrichtigungen.
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useNotificationsStore } from '../stores/notifications.js'
+
+const notifications = useNotificationsStore()
+const open = ref(false)
+const root = ref(null)
+const panelStyle = ref({})
+
+function toggle() {
+  open.value = !open.value
+  if (open.value) {
+    notifications.markSeen()
+    positionPanel()
+  }
+}
+
+function positionPanel() {
+  const rect = root.value?.getBoundingClientRect()
+  if (!rect) return
+  panelStyle.value = {
+    top:   `${rect.bottom + 8}px`,
+    right: `${window.innerWidth - rect.right}px`,
+  }
+}
+
+function onClickOutside(e) {
+  if (open.value && root.value && !root.value.contains(e.target)) open.value = false
+}
+
+function formatDate(iso) {
+  const d = new Date(iso)
+  const now = new Date()
+  const diffMin = Math.floor((now - d) / 60000)
+  if (diffMin < 1)   return 'Gerade eben'
+  if (diffMin < 60)  return `vor ${diffMin} Min.`
+  const diffH = Math.floor(diffMin / 60)
+  if (diffH < 24)    return `vor ${diffH} Std.`
+  return d.toLocaleDateString('de-CH', { day: 'numeric', month: 'short' })
+}
+
+onMounted(() => {
+  notifications.fetchAll()
+  document.addEventListener('click', onClickOutside)
+})
+onUnmounted(() => document.removeEventListener('click', onClickOutside))
+</script>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -26,6 +26,7 @@
             d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
         </svg>
       </button>
+      <NotificationBell />
       <button @click="showHelp = true"
         class="p-1.5 rounded-md text-neutral-400 hover:text-white hover:bg-white/10 transition-colors"
         title="Hilfe">
@@ -49,6 +50,7 @@ import { useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useDarkMode } from '../composables/useDarkMode.js'
 import HelpModal from './HelpModal.vue'
+import NotificationBell from './NotificationBell.vue'
 
 const auth     = useAuthStore()
 const route    = useRoute()

--- a/src/stores/notifications.js
+++ b/src/stores/notifications.js
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { api } from '../api/index.js'
+
+const SEEN_KEY = 'notifications-last-seen'
+
+export const useNotificationsStore = defineStore('notifications', () => {
+  const list    = ref([])
+  const loading = ref(false)
+
+  const lastSeen = ref(localStorage.getItem(SEEN_KEY) ?? '1970-01-01T00:00:00')
+
+  const unseenCount = computed(() =>
+    list.value.filter(n => n.created_at > lastSeen.value).length
+  )
+
+  async function fetchAll() {
+    loading.value = true
+    try { list.value = await api.getNotifications() }
+    finally { loading.value = false }
+  }
+
+  function markSeen() {
+    const now = new Date().toISOString()
+    lastSeen.value = now
+    localStorage.setItem(SEEN_KEY, now)
+  }
+
+  return { list, loading, unseenCount, fetchAll, markSeen }
+})


### PR DESCRIPTION
## Summary

Frontend half of #65. Depends on [abteilung-webit-api#50](https://github.com/sbw-neue-medien/abteilung-webit-api/pull/50).

- `src/api/index.js` — `getNotifications()` call
- `src/stores/notifications.js` — fetches `GET /notifications`; tracks last-seen timestamp in localStorage; exposes `unseenCount`
- `src/components/NotificationBell.vue` — bell icon in TopBar with:
  - Red badge showing unseen count (cleared on open, persisted to localStorage)
  - Teleported dropdown panel: subject + relative timestamp + recipient count per event
  - Click-outside closes the panel
- `src/components/TopBar.vue` — bell inserted between dark-mode toggle and help button

## Test plan

- [ ] Bell appears in TopBar for all roles
- [ ] Leiter: sees all events, one per `correlation_id`, with recipient count
- [ ] Lernender/mentor: sees only events addressed to their email
- [ ] Badge count resets to 0 after opening the panel
- [ ] Badge reappears after new notifications arrive (re-fetch)
- [ ] Panel closes on click outside
- [ ] Relative timestamps display correctly (minutes, hours, date)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)