### PR TITLE
feat: RSS feed subscribe link in NotificationBell

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -98,4 +98,5 @@ export const api = {
   getRoles: ()                     => req('/roles'),
   updateRolePermissions: (role, permissions) => req(`/roles/${role}/permissions`, { method: 'PUT', body: JSON.stringify({ permissions }) }),
   getNotifications: ()             => req('/notifications'),
+  getNotificationFeedUrl: ()       => req('/notifications/feed-url'),
 }

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -20,7 +20,13 @@
            :style="panelStyle">
         <div class="flex items-center justify-between px-4 py-3 border-b border-groove shrink-0">
           <span class="text-sm font-semibold text-hi">Benachrichtigungen</span>
-          <span v-if="notifications.loading" class="text-xs text-lo">Laden…</span>
+          <div class="flex items-center gap-2">
+            <span v-if="notifications.loading" class="text-xs text-lo">Laden…</span>
+            <a v-if="auth.isLeiter && feedUrl" :href="feedUrl" target="_blank" rel="noopener"
+               class="text-xs text-lo hover:text-brand-600 transition-colors" title="RSS Feed abonnieren">
+              RSS
+            </a>
+          </div>
         </div>
 
         <ul v-if="notifications.list.length" class="overflow-y-auto divide-y divide-groove">
@@ -42,13 +48,17 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useNotificationsStore } from '../stores/notifications.js'
+import { useAuthStore } from '../stores/auth.js'
+import { api } from '../api/index.js'
 
 const notifications = useNotificationsStore()
-const open = ref(false)
-const root = ref(null)
+const auth     = useAuthStore()
+const open     = ref(false)
+const root     = ref(null)
 const panelStyle = ref({})
+const feedUrl  = ref(null)
 
 function toggle() {
   open.value = !open.value
@@ -82,8 +92,12 @@ function formatDate(iso) {
   return d.toLocaleDateString('de-CH', { day: 'numeric', month: 'short' })
 }
 
-onMounted(() => {
+onMounted(async () => {
   notifications.fetchAll()
+  if (auth.isLeiter) {
+    const res = await api.getNotificationFeedUrl()
+    feedUrl.value = res?.url ?? null
+  }
   document.addEventListener('click', onClickOutside)
 })
 onUnmounted(() => document.removeEventListener('click', onClickOutside))


### PR DESCRIPTION
## Summary

Frontend half of #66. Depends on [abteilung-webit-api#51](https://github.com/sbw-neue-medien/abteilung-webit-api/pull/51).

- `api.getNotificationFeedUrl()` — new API call to `GET /notifications/feed-url`
- `NotificationBell`: fetches feed URL on mount for leiter; shows an **RSS** link in the dropdown header that opens the feed in a new tab (works as Teams connector URL or browser feed subscription)

Closes #66

## Test plan

- [ ] As leiter: RSS link visible in bell dropdown header
- [ ] Clicking RSS opens the feed URL in a new tab
- [ ] As lernender/mentor: no RSS link shown
- [ ] Feed URL matches `APP_URL/notifications/feed?token=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)