### PR TITLE
fix: confirm popup overflows when delete button is at right edge

### DIFF
--- a/src/components/ConfirmButton.vue
+++ b/src/components/ConfirmButton.vue
@@ -3,7 +3,7 @@
     <button type="button" v-bind="attrs" :class="{ invisible: pending }" @click.stop="ask">
       <slot />
     </button>
-    <span v-if="pending" class="absolute top-0 left-0 z-20 flex items-center gap-1 whitespace-nowrap rounded-lg bg-surface ring-1 ring-line shadow-lg px-2 py-1">
+    <span v-if="pending" class="absolute top-0 right-0 z-20 flex items-center gap-1 whitespace-nowrap rounded-lg bg-surface ring-1 ring-line shadow-lg px-2 py-1">
       <span class="text-xs text-mid">{{ label }}</span>
       <button type="button" class="btn btn-xs btn-danger" @click.stop="confirm">✓</button>
       <button type="button" class="btn btn-xs btn-secondary" @click.stop="reset">✕</button>


### PR DESCRIPTION
Fixes #76

## Root cause
`ConfirmButton`'s confirmation popup was positioned with `left-0`, causing it to expand rightward off-screen whenever the trigger button was near the right edge of a card or dialog.

## Fix
Changed to `right-0` — the popup's right edge now aligns with the button and expands leftward, staying within the viewport for all current button placements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)