### PR TITLE
feat: optional mentor per project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "webit-abteilung",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/components/ProjectForm.vue
+++ b/src/components/ProjectForm.vue
@@ -47,6 +47,14 @@
         </div>
       </div>
 
+      <div v-if="mentors.length">
+        <label class="label">Mentor (optional)</label>
+        <select v-model="form.mentor_id" class="input">
+          <option :value="null">— Kein Mentor —</option>
+          <option v-for="m in mentors" :key="m.id" :value="m.id">{{ m.name }}</option>
+        </select>
+      </div>
+
       <template v-if="!project">
         <div v-if="templates.length && !form.is_template">
           <label class="label">Vorlage verwenden</label>
@@ -80,6 +88,7 @@ import MarkdownTextarea from './MarkdownTextarea.vue'
 const props = defineProps({
   project:      Object,
   users:        { type: Array, default: () => [] },
+  mentors:      { type: Array, default: () => [] },
   templates:    { type: Array, default: () => [] },
   loading:      Boolean,
   personalOnly: { type: Boolean, default: false },
@@ -88,7 +97,7 @@ const emit = defineEmits(['submit', 'cancel'])
 
 const form = ref({
   name: '', client: '', description: '', status: 'geplant',
-  is_personal: false, owner_id: null, member_ids: [],
+  is_personal: false, owner_id: null, member_ids: [], mentor_id: null,
   is_template: false, template_id: null,
 })
 
@@ -102,6 +111,7 @@ watch(() => props.project, (p) => {
     is_personal: !!p.is_personal,
     owner_id:    p.is_personal ? (p.owner_id ?? null) : null,
     member_ids:  p.members ? p.members.map(m => m.id) : (p.member_ids ?? []),
+    mentor_id:   p.mentor_id ?? null,
     is_template: false,
     template_id: null,
   }

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -137,7 +137,7 @@
     </Modal>
 
     <Modal v-model="showEdit" title="Projekt bearbeiten">
-      <ProjectForm :project="projects.current" :users="allUsers" :loading="saving"
+      <ProjectForm :project="projects.current" :users="allUsers" :mentors="mentors" :loading="saving"
         @submit="saveProject" @cancel="showEdit = false" />
     </Modal>
 
@@ -192,6 +192,7 @@ const canEditOwnDescription = computed(() =>
   projects.current?.owner_id === auth.user?.id
 )
 const allUsers       = ref([])
+const mentors        = ref([])
 const sprintFilter   = ref(null)
 const isSerie        = ref(false)
 const serieSprintIds = ref([])
@@ -217,6 +218,9 @@ onMounted(async () => {
   if (auth.can('projects.manage_members')) {
     await usersStore.fetchAll()
     allUsers.value = usersStore.list.filter(u => u.role === 'lernender' && u.active)
+  }
+  if (auth.can('projects.update')) {
+    mentors.value = await api.getMentors()
   }
 })
 

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -65,7 +65,10 @@
             </span>
           </div>
           <div class="flex items-center justify-between mt-auto pt-2 border-t border-groove">
-            <span class="text-xs text-lo">{{ p.owner_name }}</span>
+            <div class="flex flex-col gap-0.5">
+              <span class="text-xs text-lo">{{ p.owner_name }}</span>
+              <span v-if="p.mentor_name" class="text-xs text-lo">Mentor: {{ p.mentor_name }}</span>
+            </div>
             <div v-if="canEditProject(p)" class="flex gap-1" @click.stop>
               <button class="btn btn-sm btn-secondary" @click="openEdit(p)">Bearbeiten</button>
               <ConfirmButton class="btn btn-sm btn-danger" :label="`Projekt «${p.name}» wirklich löschen?`" @confirm="confirmDelete(p)">Löschen</ConfirmButton>
@@ -101,6 +104,7 @@
       <ProjectForm
         :project="editing"
         :users="auth.can('projects.create') ? users.list.filter(u => u.role === 'lernender' && u.active) : []"
+        :mentors="auth.can('projects.create') ? mentors : []"
         :templates="activeTab === 'projekte' ? projects.templates : []"
         :loading="saving"
         :personal-only="!auth.can('projects.create')"
@@ -117,6 +121,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth.js'
 import { useProjectsStore } from '../stores/projects.js'
 import { useUsersStore } from '../stores/users.js'
+import { api } from '../api/index.js'
 import ConfirmButton from '../components/ConfirmButton.vue'
 import StatusBadge from '../components/StatusBadge.vue'
 import Modal from '../components/Modal.vue'
@@ -132,6 +137,7 @@ const projects = useProjectsStore()
 const users    = useUsersStore()
 const router   = useRouter()
 
+const mentors        = ref([])
 const showModal      = ref(false)
 const editing        = ref(null)
 const saving         = ref(false)
@@ -178,11 +184,12 @@ function canEditProject(p) {
   return auth.can('projects.update_own') && p.is_personal && p.owner_id === auth.user?.id
 }
 
-onMounted(() => {
+onMounted(async () => {
   projects.fetchAll()
   if (auth.can('projects.create')) {
     users.fetchAll()
     projects.fetchTemplates()
+    mentors.value = await api.getMentors()
   }
 })
 


### PR DESCRIPTION
Part of sbw-neue-medien/abteilung-webit-api#55. See also API PR (matching branch).

## Summary
- `ProjectForm` gains a mentor dropdown (leiter-only, optional) bound to `mentor_id`
- `ProjectsView` fetches the mentors list on mount and passes it to the form
- Mentor name shown on the project card when set

## Deploy note
Run `migration_project_mentor.sql` on the database before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)