### PR TITLE
feat: replace Kanban scrollbar with arrow navigation + snap scroll

### DIFF
--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -1,53 +1,81 @@
 <template>
-  <div class="flex gap-4 overflow-x-auto pb-4 min-h-[60vh]">
-    <div v-for="col in columns" :key="col.status"
-      class="flex-shrink-0 w-60 flex flex-col gap-2"
-      @dragover.prevent
-      @dragenter.prevent="onDragEnter(col.status)"
-      @dragleave="dragOver = null"
-      @drop="handleDrop($event, col.status)"
-      :class="{ 'ring-2 ring-brand-500 ring-offset-2 ring-offset-bg rounded-xl': !readonly && dragOver === col.status }">
+  <div class="relative">
+    <button
+      v-if="canScrollLeft"
+      @click="scrollBy(-1)"
+      class="absolute left-0 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full bg-surface ring-1 ring-line shadow-md text-mid hover:text-hi transition-colors -translate-x-1/2"
+      aria-label="Nach links scrollen"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+      </svg>
+    </button>
 
-      <div class="flex items-center justify-between px-1">
-        <div class="flex items-center gap-2">
-          <span class="w-2 h-2 rounded-full" :class="col.dot" />
-          <h3 class="text-sm font-semibold text-hi">{{ col.label }}</h3>
-          <span class="text-xs text-lo bg-lift rounded-full px-1.5">
-            {{ tasksFor(col.status).length }}
-          </span>
+    <div
+      ref="scrollEl"
+      class="flex gap-4 overflow-x-auto pb-4 min-h-[60vh] snap-x snap-mandatory scrollbar-hide"
+      @scroll.passive="onScroll"
+    >
+      <div v-for="col in columns" :key="col.status"
+        class="flex-shrink-0 w-60 flex flex-col gap-2 snap-center"
+        @dragover.prevent
+        @dragenter.prevent="onDragEnter(col.status)"
+        @dragleave="dragOver = null"
+        @drop="handleDrop($event, col.status)"
+        :class="{ 'ring-2 ring-brand-500 ring-offset-2 ring-offset-bg rounded-xl': !readonly && dragOver === col.status }">
+
+        <div class="flex items-center justify-between px-1">
+          <div class="flex items-center gap-2">
+            <span class="w-2 h-2 rounded-full" :class="col.dot" />
+            <h3 class="text-sm font-semibold text-hi">{{ col.label }}</h3>
+            <span class="text-xs text-lo bg-lift rounded-full px-1.5">
+              {{ tasksFor(col.status).length }}
+            </span>
+          </div>
+          <button v-if="!readonly" @click="$emit('add', col.status)"
+                  class="text-lo hover:text-brand-600 transition-colors" title="Aufgabe hinzufügen">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+          </button>
         </div>
-        <button v-if="!readonly" @click="$emit('add', col.status)"
-                class="text-lo hover:text-brand-600 transition-colors" title="Aufgabe hinzufügen">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-          </svg>
-        </button>
-      </div>
 
-      <div class="flex flex-col gap-2 flex-1 rounded-xl p-2 bg-lift/60 min-h-[100px]">
-        <KanbanCard
-          v-for="task in tasksFor(col.status)"
-          :key="task.id"
-          :task="task"
-          :readonly="readonly"
-          @duplicate="$emit('duplicate', $event)"
-          @edit="$emit('edit', $event)"
-          @delete="$emit('delete', $event)"
-          @zoom="zoomedTask = $event"
-        />
-        <div v-if="tasksFor(col.status).length === 0"
-             class="flex-1 flex items-center justify-center text-xs text-lo italic py-4">
-          Leer
+        <div class="flex flex-col gap-2 flex-1 rounded-xl p-2 bg-lift/60 min-h-[100px]">
+          <KanbanCard
+            v-for="task in tasksFor(col.status)"
+            :key="task.id"
+            :task="task"
+            :readonly="readonly"
+            @duplicate="$emit('duplicate', $event)"
+            @edit="$emit('edit', $event)"
+            @delete="$emit('delete', $event)"
+            @zoom="zoomedTask = $event"
+          />
+          <div v-if="tasksFor(col.status).length === 0"
+               class="flex-1 flex items-center justify-center text-xs text-lo italic py-4">
+            Leer
+          </div>
         </div>
       </div>
     </div>
+
+    <button
+      v-if="canScrollRight"
+      @click="scrollBy(1)"
+      class="absolute right-0 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full bg-surface ring-1 ring-line shadow-md text-mid hover:text-hi transition-colors translate-x-1/2"
+      aria-label="Nach rechts scrollen"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+      </svg>
+    </button>
   </div>
 
   <TaskZoomModal :task="zoomedTask" @close="zoomedTask = null" />
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import KanbanCard from './KanbanCard.vue'
 import TaskZoomModal from './TaskZoomModal.vue'
 
@@ -61,8 +89,38 @@ const columns = [
   { status: 'erledigt',  label: 'Erledigt',  dot: 'bg-brand-500' },
 ]
 
-const dragOver  = ref(null)
+const dragOver   = ref(null)
 const zoomedTask = ref(null)
+const scrollEl   = ref(null)
+const canScrollLeft  = ref(false)
+const canScrollRight = ref(false)
+
+function updateScrollState() {
+  const el = scrollEl.value
+  if (!el) return
+  canScrollLeft.value  = el.scrollLeft > 0
+  canScrollRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+}
+
+function onScroll() {
+  updateScrollState()
+}
+
+function scrollBy(dir) {
+  const el = scrollEl.value
+  if (!el) return
+  const colWidth = 240 + 16 // w-60 (240px) + gap-4 (16px)
+  el.scrollBy({ left: dir * colWidth, behavior: 'smooth' })
+}
+
+onMounted(() => {
+  updateScrollState()
+  window.addEventListener('resize', updateScrollState)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateScrollState)
+})
 
 function tasksFor(status) {
   return (props.tasks ?? []).filter(t => t.status === status)

--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -13,11 +13,11 @@
 
     <div
       ref="scrollEl"
-      class="flex gap-4 overflow-x-auto pb-4 min-h-[60vh] snap-x snap-mandatory scrollbar-hide"
+      class="flex gap-2 overflow-x-auto pb-4 min-h-[60vh] snap-x snap-mandatory scrollbar-hide"
       @scroll.passive="onScroll"
     >
       <div v-for="col in columns" :key="col.status"
-        class="flex-shrink-0 w-72 flex flex-col gap-2 snap-center"
+        class="flex-shrink-0 w-[19rem] flex flex-col gap-2 snap-center"
         @dragover.prevent
         @dragenter.prevent="onDragEnter(col.status)"
         @dragleave="dragOver = null"
@@ -109,7 +109,7 @@ function onScroll() {
 function scrollBy(dir) {
   const el = scrollEl.value
   if (!el) return
-  const colWidth = 288 + 16 // w-72 (288px) + gap-4 (16px)
+  const colWidth = 304 + 8 // w-[19rem] (304px) + gap-2 (8px)
   el.scrollBy({ left: dir * colWidth, behavior: 'smooth' })
 }
 

--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div class="relative max-w-7xl mx-auto">
     <button
       v-if="canScrollLeft"
       @click="scrollBy(-1)"

--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -17,7 +17,7 @@
       @scroll.passive="onScroll"
     >
       <div v-for="col in columns" :key="col.status"
-        class="flex-shrink-0 w-60 flex flex-col gap-2 snap-center"
+        class="flex-shrink-0 w-72 flex flex-col gap-2 snap-center"
         @dragover.prevent
         @dragenter.prevent="onDragEnter(col.status)"
         @dragleave="dragOver = null"
@@ -109,7 +109,7 @@ function onScroll() {
 function scrollBy(dir) {
   const el = scrollEl.value
   if (!el) return
-  const colWidth = 240 + 16 // w-60 (240px) + gap-4 (16px)
+  const colWidth = 288 + 16 // w-72 (288px) + gap-4 (16px)
   el.scrollBy({ left: dir * colWidth, behavior: 'smooth' })
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -35,6 +35,15 @@
   }
 }
 
+@layer utilities {
+  .scrollbar-hide {
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @layer components {
   .btn {
     @apply inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:ring-offset-bg;

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -45,10 +45,8 @@
         </button>
       </div>
 
-      <div class="max-w-7xl mx-auto">
-        <KanbanBoard :tasks="filteredTasks" :readonly="!auth.can('tasks.create')"
-                     @move="moveTask" @add="addTask" @duplicate="duplicateTask" @edit="openEditTask" @delete="deleteTask" />
-      </div>
+      <KanbanBoard :tasks="filteredTasks" :readonly="!auth.can('tasks.create')"
+                   @move="moveTask" @add="addTask" @duplicate="duplicateTask" @edit="openEditTask" @delete="deleteTask" />
 
       <div v-if="auth.can('projects.manage_members') && projects.current.members?.length" class="mt-6 max-w-7xl mx-auto">
         <h3 class="text-sm font-semibold text-lo uppercase tracking-wide mb-2">Mitglieder</h3>


### PR DESCRIPTION
## Summary

- Adds left/right arrow buttons that appear only when there is content to scroll in that direction; hidden automatically when all 4 columns fit the viewport
- Snap scroll per column (`snap-x snap-mandatory` + `snap-center`) so each click lands cleanly on the next column
- Native scrollbar hidden via new `scrollbar-hide` utility class (`scrollbar-width: none` + `-webkit-scrollbar: none`)
- Arrow buttons update reactively on scroll and window resize

Closes #81

## Test plan

- [ ] On a narrow viewport: left arrow hidden at start, right arrow visible → click right steps one column → left arrow appears
- [ ] After scrolling to last column: right arrow disappears
- [ ] On a wide viewport where all 4 columns fit: no arrows shown at all
- [ ] Snap scroll lands cleanly on column boundaries
- [ ] No native scrollbar visible in Chrome, Firefox, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)