### PR TITLE
feat: default board to current sprint on open

### DIFF
--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -192,6 +192,12 @@ const canEditOwnDescription = computed(() =>
 const allUsers       = ref([])
 const mentors        = ref([])
 const sprintFilter   = ref(null)
+
+function currentSprintId() {
+  const today = new Date().toISOString().slice(0, 10)
+  const active = sprints.list.find(s => s.start_date <= today && s.end_date >= today)
+  return active?.id ?? null
+}
 const isSerie        = ref(false)
 const serieSprintIds = ref([])
 const taskForm       = ref({
@@ -213,6 +219,7 @@ onMounted(async () => {
     todos.fetchForProject(id),
     sprints.fetchAll(),
   ])
+  sprintFilter.value = currentSprintId()
   if (auth.can('projects.manage_members')) {
     await usersStore.fetchAll()
     allUsers.value = usersStore.list.filter(u => u.role === 'lernender' && u.active)


### PR DESCRIPTION
## Summary

- On mount, finds the sprint whose `start_date`/`end_date` bracket today and selects it as the initial filter
- Falls back to «all tasks» (`null`) when no sprint is currently active
- Sprint filter bar and backlog navigation are unchanged

Closes #83

## Test plan

- [ ] Open a project board mid-sprint → correct sprint tab is pre-selected
- [ ] Open board when no sprint is active → all tasks shown (no filter)
- [ ] Manually switching to another sprint / backlog still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)