### PR TITLE
Fix #88: Zeiterfassung-Tabelle overflow

### DIFF
--- a/src/views/TimeEntryView.vue
+++ b/src/views/TimeEntryView.vue
@@ -44,7 +44,7 @@
       </div>
     </div>
 
-    <div class="card overflow-hidden p-0">
+    <div class="card overflow-x-auto p-0">
       <table class="min-w-full text-sm">
         <thead class="bg-lift border-b border-line">
           <tr>


### PR DESCRIPTION
## Summary

- `overflow-hidden` → `overflow-x-auto` am Tabellen-Container in `TimeEntryView.vue`
- Tabelle scrollt jetzt horizontal statt Buttons abzuschneiden

## Test plan

- [ ] Zeiterfassung aufrufen (Leiter)
- [ ] Fensterbreite reduzieren → Tabelle scrollt, Buttons bleiben erreichbar
- [ ] Normale Breite: keine sichtbare Änderung

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)