### PR TITLE
Lead-Time-Ansicht für Coaches dokumentieren

### DIFF
--- a/docs/howto-mentoren.md
+++ b/docs/howto-mentoren.md
@@ -47,17 +47,27 @@ Du erhältst automatisch eine E-Mail-Benachrichtigung, wenn einer deiner Lernend
 
 ---
 
+## Lead Time
+
+Unter **Lead Time** siehst du, wie viel Prozent der verfügbaren Betriebszeit deine Lernenden im gewählten Zeitraum verbucht haben.
+
+- Wähle oben einen Zeitraum (Woche / Monat / Quartal / benutzerdefiniert)
+- Jeder Lernende wird als Balken dargestellt: grün (≥ 80 %), gelb (≥ 50 %), rot (< 50 %)
+- Es werden nur deine zugeordneten Lernenden angezeigt
+
+---
+
 ## Hinweis zu Berechtigungen
 
 | Aktion | Möglich? |
 |--------|----------|
 | Projekte & Aufgaben ansehen | Ja |
 | Zeiteinträge der Lernenden ansehen | Ja |
+| Lead-Time-Statistiken ansehen (eigene Lernende) | Ja |
 | Eigenes Passwort ändern | Ja |
 | E-Mail-Benachrichtigungen steuern | Ja |
 | Aufgaben erstellen / bearbeiten | Nein |
 | Zeiteinträge erstellen / bearbeiten | Nein |
-| Lead-Time-Statistiken einsehen | Nein |
 | Lernende verwalten | Nein |
 
 

--- a/management_summary.md
+++ b/management_summary.md
@@ -23,7 +23,7 @@ Das webIT Abteilungs-Dashboard ist eine interne Webanwendung zur Verwaltung der 
 |---|---|
 | **Leiter** | Vollzugriff — verwaltet Benutzer, Projekte, Sprints, Coaches und Berechtigungen |
 | **Lernpartner** | Sieht eigene und zugewiesene Projekte, erfasst seine Arbeitszeiten |
-| **Coach** | Lesezugriff auf die Daten der zugewiesenen Lernpartner, kein Schreibzugriff |
+| **Coach** | Lesezugriff auf die Daten der zugewiesenen Lernpartner inkl. Lead-Time-Ansicht, kein Schreibzugriff |
 
 ## Was kann die Anwendung?
 
@@ -68,7 +68,7 @@ Damit ist es möglich, einen Lernpartner als **Projektleiter** für ein bestimmt
 
 ### Neu in Version 1.9.x
 
-- **Lead-Time-Ansicht** — Leiter sehen auf einen Blick, wie viel Prozent der verfügbaren Brutto-Arbeitszeit jeder Lernpartner im gewählten Zeitraum verbucht hat. Ein farbiger Fortschrittsbalken (grün ≥ 80 %, gelb ≥ 50 %, rot < 50 %) ermöglicht eine schnelle Einschätzung der Auslastung. Der Zeitraum wird über einen flexiblen Perioden-Selektor (Woche / Monat / Quartal / benutzerdefiniert) gesteuert. Die verfügbare Bruttozeit wird automatisch aus den Werktagen und der täglichen Netto-Betriebszeit (225 min) berechnet.
+- **Lead-Time-Ansicht** — Leiter und Coaches sehen auf einen Blick, wie viel Prozent der verfügbaren Brutto-Arbeitszeit jeder Lernpartner im gewählten Zeitraum verbucht hat. Coaches sehen dabei nur ihre zugeordneten Lernpartner. Ein farbiger Fortschrittsbalken (grün ≥ 80 %, gelb ≥ 50 %, rot < 50 %) ermöglicht eine schnelle Einschätzung der Auslastung. Der Zeitraum wird über einen flexiblen Perioden-Selektor (Woche / Monat / Quartal / benutzerdefiniert) gesteuert. Die verfügbare Bruttozeit wird automatisch aus den Werktagen und der täglichen Netto-Betriebszeit (225 min) berechnet.
 
 ## Aktueller Stand
 


### PR DESCRIPTION
Closes #100

## Summary

- `docs/howto-mentoren.md` — Abschnitt „Lead Time" hinzugefügt; Berechtigungstabelle auf gefilterten Zugriff (eigene Lernende) aktualisiert
- `management_summary.md` — Coach-Zeile und Lead-Time-Beschreibung auf eingeschränkten Zugriff angepasst

## Test plan

- [ ] Hilfe-Modal als Mentor öffnen → Abschnitt „Lead Time" sichtbar
- [ ] Berechtigungstabelle zeigt „Lead-Time-Statistiken ansehen (eigene Lernende) | Ja"

🤖 Generated with [Claude Code](https://claude.com/claude-code)