### PR TITLE
Kanban: Navigation in feste Kopfzeile neben Spalten-Labels

### DIFF
--- a/public/management-summary.html
+++ b/public/management-summary.html
@@ -162,11 +162,11 @@
   <header>
     <div class="label">webIT Abteilung</div>
     <h1>Management Summary</h1>
-    <span class="version">1.8.0</span>
+    <span class="version">1.9.5</span>
   </header>
   <main>
-    <h1 id="stand-der-anwendung-version-1.8.0">Stand der Anwendung —
-    Version 1.8.0</h1>
+    <h1 id="stand-der-anwendung-version-1.9.5">Stand der Anwendung —
+    Version 1.9.5</h1>
     <h2 id="worum-geht-es">Worum geht es?</h2>
     <p>Das webIT Abteilungs-Dashboard ist eine interne Webanwendung zur
     Verwaltung der Abteilungsarbeit. Es ermöglicht Lernenden, Leitern
@@ -198,8 +198,8 @@
     </tr>
     <tr>
     <td><strong>Coach</strong></td>
-    <td>Lesezugriff auf die Daten der zugewiesenen Lernpartner, kein
-    Schreibzugriff</td>
+    <td>Lesezugriff auf die Daten der zugewiesenen Lernpartner inkl.
+    Lead-Time-Ansicht, kein Schreibzugriff</td>
     </tr>
     </tbody>
     </table>
@@ -309,8 +309,21 @@
     <li><strong>Erweiterte E-Mail-Benachrichtigungen</strong> — Leiter
     und Coaches werden bei neuen Eigenprojekten benachrichtigt</li>
     </ul>
+    <h3 id="neu-in-version-1.9.x">Neu in Version 1.9.x</h3>
+    <ul>
+    <li><strong>Lead-Time-Ansicht</strong> — Leiter und Coaches sehen
+    auf einen Blick, wie viel Prozent der verfügbaren Brutto-Arbeitszeit
+    jeder Lernpartner im gewählten Zeitraum verbucht hat. Coaches sehen
+    dabei nur ihre zugeordneten Lernpartner. Ein farbiger
+    Fortschrittsbalken (grün ≥ 80 %, gelb ≥ 50 %, rot &lt; 50 %)
+    ermöglicht eine schnelle Einschätzung der Auslastung. Der Zeitraum
+    wird über einen flexiblen Perioden-Selektor (Woche / Monat / Quartal
+    / benutzerdefiniert) gesteuert. Die verfügbare Bruttozeit wird
+    automatisch aus den Werktagen und der täglichen Netto-Betriebszeit
+    (225 min) berechnet.</li>
+    </ul>
     <h2 id="aktueller-stand">Aktueller Stand</h2>
-    <p>Die Anwendung ist produktiv im Einsatz. Version 1.8.0 wurde im
+    <p>Die Anwendung ist produktiv im Einsatz. Version 1.9.5 wurde im
     Mai 2026 veröffentlicht.</p>
     <p><strong>Produktions-Hinweis:</strong> Beim Deployment einer neuen
     Version müssen Datenbank-Migrationen manuell auf dem Plesk-Server

--- a/src/components/KanbanBoard.vue
+++ b/src/components/KanbanBoard.vue
@@ -1,30 +1,22 @@
 <template>
-  <div class="relative max-w-7xl mx-auto">
-    <button
-      v-if="canScrollLeft"
-      @click="scrollBy(-1)"
-      class="absolute left-0 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full bg-surface ring-1 ring-line shadow-md text-mid hover:text-hi transition-colors -translate-x-1/2"
-      aria-label="Nach links scrollen"
-    >
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
-      </svg>
-    </button>
+  <div class="max-w-7xl mx-auto">
 
-    <div
-      ref="scrollEl"
-      class="flex gap-2 overflow-x-auto pb-4 min-h-[60vh] snap-x snap-mandatory scrollbar-hide"
-      @scroll.passive="onScroll"
-    >
-      <div v-for="col in columns" :key="col.status"
-        class="flex-shrink-0 w-[19rem] flex flex-col gap-2 snap-center"
-        @dragover.prevent
-        @dragenter.prevent="onDragEnter(col.status)"
-        @dragleave="dragOver = null"
-        @drop="handleDrop($event, col.status)"
-        :class="{ 'ring-2 ring-brand-500 ring-offset-2 ring-offset-bg rounded-xl': !readonly && dragOver === col.status }">
+    <!-- Fixed header row: nav arrows + column labels -->
+    <div class="flex items-center gap-1 mb-2">
+      <button
+        :class="canScrollLeft ? 'text-mid hover:text-hi' : 'invisible'"
+        @click="scrollBy(-1)"
+        class="shrink-0 flex items-center justify-center w-7 h-7 rounded-full bg-surface ring-1 ring-line shadow-sm transition-colors"
+        aria-label="Nach links scrollen"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+      </button>
 
-        <div class="flex items-center justify-between px-1">
+      <div ref="headerEl" class="flex-1 flex gap-2 overflow-x-hidden">
+        <div v-for="col in columns" :key="col.status"
+             class="flex-shrink-0 w-[19rem] flex items-center justify-between px-1">
           <div class="flex items-center gap-2">
             <span class="w-2 h-2 rounded-full" :class="col.dot" />
             <h3 class="text-sm font-semibold text-hi">{{ col.label }}</h3>
@@ -39,6 +31,33 @@
             </svg>
           </button>
         </div>
+      </div>
+
+      <button
+        :class="canScrollRight ? 'text-mid hover:text-hi' : 'invisible'"
+        @click="scrollBy(1)"
+        class="shrink-0 flex items-center justify-center w-7 h-7 rounded-full bg-surface ring-1 ring-line shadow-sm transition-colors"
+        aria-label="Nach rechts scrollen"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Scrollable card area (no column headers) -->
+    <div
+      ref="scrollEl"
+      class="flex gap-2 overflow-x-auto pb-4 min-h-[60vh] snap-x snap-mandatory scrollbar-hide"
+      @scroll.passive="onScroll"
+    >
+      <div v-for="col in columns" :key="col.status"
+        class="flex-shrink-0 w-[19rem] flex flex-col gap-2 snap-center"
+        @dragover.prevent
+        @dragenter.prevent="onDragEnter(col.status)"
+        @dragleave="dragOver = null"
+        @drop="handleDrop($event, col.status)"
+        :class="{ 'ring-2 ring-brand-500 ring-offset-2 ring-offset-bg rounded-xl': !readonly && dragOver === col.status }">
 
         <div class="flex flex-col gap-2 flex-1 rounded-xl p-2 bg-lift/60 min-h-[100px]">
           <KanbanCard
@@ -59,16 +78,6 @@
       </div>
     </div>
 
-    <button
-      v-if="canScrollRight"
-      @click="scrollBy(1)"
-      class="absolute right-0 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-8 h-8 rounded-full bg-surface ring-1 ring-line shadow-md text-mid hover:text-hi transition-colors translate-x-1/2"
-      aria-label="Nach rechts scrollen"
-    >
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
-      </svg>
-    </button>
   </div>
 
   <TaskZoomModal :task="zoomedTask" @close="zoomedTask = null" />
@@ -92,6 +101,7 @@ const columns = [
 const dragOver   = ref(null)
 const zoomedTask = ref(null)
 const scrollEl   = ref(null)
+const headerEl   = ref(null)
 const canScrollLeft  = ref(false)
 const canScrollRight = ref(false)
 
@@ -104,6 +114,7 @@ function updateScrollState() {
 
 function onScroll() {
   updateScrollState()
+  if (headerEl.value) headerEl.value.scrollLeft = scrollEl.value.scrollLeft
 }
 
 function scrollBy(dir) {


### PR DESCRIPTION
Closes #102

## Summary

- Neue feste Kopfzeile oberhalb des Scroll-Bereichs: `[‹]  Offen · In Arbeit · Review · Erledigt  [›]`
- Pfeile verwenden `invisible` statt `v-if` → kein Layout-Sprung beim Ein-/Ausblenden
- `headerEl` scrollt per JS synchron mit dem Karten-Bereich, sodass Labels immer mit ihren Spalten fluchten
- Spalten-Header (Label + Dot + Count + Add-Button) aus dem scrollbaren Bereich entfernt — liegen jetzt nur noch in der festen Kopfzeile
- `relative`-Wrapper und `absolute`-Positionierung der alten Pfeil-Buttons entfallen

## Test plan

- [ ] Desktop (alle 4 Spalten sichtbar): keine Pfeile sichtbar, alle Labels sichtbar
- [ ] Schmal/Mobile (Snap-Scroll): `‹` / `›` sichtbar, Labels scrollen synchron mit Karten
- [ ] Add-Button (+) je Spalte funktioniert
- [ ] Drag & Drop zwischen Spalten funktioniert
- [ ] Readonly-Modus: kein Add-Button sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)