### PR TITLE
Release 1.9.6

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,17 @@
       "Bash(git -C /home/j/Projekte/webIT/api add README.md)",
       "Bash(git -C /home/j/Projekte/webIT/api commit -m ' *)",
       "Bash(git -C /home/j/Projekte/webIT/api branch -D feature/role-management feature/user-permission-overrides)",
-      "Bash(git -C /home/j/Projekte/webIT branch -D bug-timeentryform-empty feat-multicolumns-markdown fix/88-zeiterfassung-tabelle-overflow)"
+      "Bash(git -C /home/j/Projekte/webIT branch -D bug-timeentryform-empty feat-multicolumns-markdown fix/88-zeiterfassung-tabelle-overflow)",
+      "Bash(git -C /home/j/Projekte/webIT checkout main)",
+      "Bash(git -C /home/j/Projekte/webIT checkout -b feat/collapsible-description)",
+      "Bash(git -C /home/j/Projekte/webIT add src/views/ProjectDetailView.vue)",
+      "Bash(git -C /home/j/Projekte/webIT push -u origin feat/collapsible-description)",
+      "Bash(git -C /home/j/Projekte/webIT log main --oneline)",
+      "Bash(git -C /home/j/Projekte/webIT log --oneline 53bc991..main)",
+      "Bash(git -C /home/j/Projekte/webIT checkout -b chore/release-1.9.6)",
+      "Bash(git -C /home/j/Projekte/webIT merge feat/collapsible-description --no-ff -m \"Merge branch 'feat/collapsible-description' into chore/release-1.9.6\")",
+      "Bash(git -C /home/j/Projekte/webIT add package.json management_summary.md)",
+      "Bash(git -C /home/j/Projekte/webIT push -u origin chore/release-1.9.6)"
     ]
   }
 }

--- a/management_summary.md
+++ b/management_summary.md
@@ -2,7 +2,7 @@
 title: "webIT Abteilungs-Dashboard"
 subtitle: "Management Summary"
 date: "Mai 2026"
-version: "1.9.5"
+version: "1.9.6"
 lang: de
 geometry: margin=2.5cm
 fontsize: 11pt
@@ -11,7 +11,7 @@ sansfont: "DejaVu Sans"
 colorlinks: true
 ---
 
-# Stand der Anwendung — Version 1.9.5
+# Stand der Anwendung — Version 1.9.6
 
 ## Worum geht es?
 
@@ -66,12 +66,17 @@ Damit ist es möglich, einen Lernpartner als **Projektleiter** für ein bestimmt
 - **Coach: Mein Bereich** — Coaches können ihr Passwort und ihre E-Mail-Benachrichtigungen selbst verwalten
 - **Erweiterte E-Mail-Benachrichtigungen** — Leiter und Coaches werden bei neuen Eigenprojekten benachrichtigt
 
-### Neu in Version 1.9.x
+### Neu in Version 1.9.6
 
 - **Lead-Time-Ansicht** — Leiter und Coaches sehen auf einen Blick, wie viel Prozent der verfügbaren Brutto-Arbeitszeit jeder Lernpartner im gewählten Zeitraum verbucht hat. Coaches sehen dabei nur ihre zugeordneten Lernpartner. Ein farbiger Fortschrittsbalken (grün ≥ 80 %, gelb ≥ 50 %, rot < 50 %) ermöglicht eine schnelle Einschätzung der Auslastung. Der Zeitraum wird über einen flexiblen Perioden-Selektor (Woche / Monat / Quartal / benutzerdefiniert) gesteuert. Die verfügbare Bruttozeit wird automatisch aus den Werktagen und der täglichen Netto-Betriebszeit (225 min) berechnet.
 
+### Neu in Version 1.9.6
+
+- **Kanban-Navigation in der Kopfzeile** — Die Vor/Zurück-Pfeile wurden in eine feste Kopfzeile direkt neben die Spalten-Labels (Offen · In Arbeit · Review · Erledigt) verschoben. Die Labels bleiben beim Scrollen immer sichtbar und scrollen synchron mit dem Karten-Bereich mit.
+- **Einklappbare Projektbeschreibung** — Lange Beschreibungen in der Projektdetailansicht sind standardmässig eingeklappt (erste Zeile sichtbar) und können per Klick aufgeklappt werden. Das hält den Kanban-Bereich beim Öffnen eines Projekts im Blickfeld.
+
 ## Aktueller Stand
 
-Die Anwendung ist produktiv im Einsatz. Version 1.9.5 wurde im Mai 2026 veröffentlicht.
+Die Anwendung ist produktiv im Einsatz. Version 1.9.6 wurde im Mai 2026 veröffentlicht.
 
 **Produktions-Hinweis:** Beim Deployment einer neuen Version müssen Datenbank-Migrationen manuell auf dem Plesk-Server eingespielt werden, bevor der Code aktiviert wird.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "webit-abteilung",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/views/ProjectDetailView.vue
+++ b/src/views/ProjectDetailView.vue
@@ -23,7 +23,19 @@
             </button>
           </div>
         </div>
-        <MarkdownRenderer v-if="projects.current.description" class="mt-3" :content="projects.current.description" />
+        <div v-if="projects.current.description" class="mt-3">
+          <div :class="descOpen ? '' : 'max-h-[3.5rem] overflow-hidden relative'">
+            <MarkdownRenderer :content="projects.current.description" />
+            <div v-if="!descOpen" class="absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-bg to-transparent pointer-events-none" />
+          </div>
+          <button @click="descOpen = !descOpen"
+                  class="mt-1 flex items-center gap-1 text-xs text-lo hover:text-mid transition-colors">
+            <svg class="w-3 h-3 transition-transform" :class="descOpen ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+            {{ descOpen ? 'Weniger anzeigen' : 'Mehr anzeigen' }}
+          </button>
+        </div>
       </div>
 
       <!-- Sprint filter bar -->
@@ -182,6 +194,7 @@ const usersStore = useUsersStore()
 const showTaskModal  = ref(false)
 const showEdit       = ref(false)
 const showDescEdit   = ref(false)
+const descOpen       = ref(false)
 const descDraft      = ref('')
 const editingTask    = ref(null)
 const saving         = ref(false)


### PR DESCRIPTION
## Release 1.9.6

### Änderungen

- **Kanban-Navigation in der Kopfzeile** (#102) — Vor/Zurück-Pfeile in feste Kopfzeile neben Spalten-Labels verschoben; Labels scrollen synchron mit dem Karten-Bereich
- **Einklappbare Projektbeschreibung** (#104) — Lange Beschreibungen standardmässig eingeklappt, per Klick aufklappbar

### Enthaltene PRs

- #103 feat: Kanban-Navigation in feste Kopfzeile
- #105 feat: Projektbeschreibung ein-/ausklappbar

### Deployment

Keine Datenbank-Migrationen erforderlich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)