### PR TITLE
Group project selects by status, remove redundant permissions section

### DIFF
--- a/src/components/ProjectSelect.vue
+++ b/src/components/ProjectSelect.vue
@@ -1,0 +1,31 @@
+<template>
+  <select :value="modelValue" class="input" v-bind="$attrs" @change="$emit('update:modelValue', toValue($event.target.value))">
+    <option v-if="placeholder" :value="placeholderValue">{{ placeholder }}</option>
+    <optgroup v-if="active.length" label="Aktiv">
+      <option v-for="p in active" :key="p.id" :value="p.id">{{ p.name }}</option>
+    </optgroup>
+    <optgroup v-if="planned.length" label="Geplant">
+      <option v-for="p in planned" :key="p.id" :value="p.id">{{ p.name }}</option>
+    </optgroup>
+  </select>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: [Number, String, null], default: '' },
+  projects: { type: Array, required: true },
+  placeholder: { type: String, default: '' },
+  placeholderValue: { type: [Number, String, null], default: '' },
+})
+defineEmits(['update:modelValue'])
+
+const active  = computed(() => props.projects.filter(p => p.status === 'aktiv'))
+const planned = computed(() => props.projects.filter(p => p.status === 'geplant'))
+
+function toValue(raw) {
+  if (raw === String(props.placeholderValue)) return props.placeholderValue
+  return Number(raw)
+}
+</script>

--- a/src/components/TimeEntryForm.vue
+++ b/src/components/TimeEntryForm.vue
@@ -7,10 +7,7 @@
     </div>
     <div>
       <label class="label">Projekt</label>
-      <select v-model="form.project_id" class="input" required>
-        <option value="">— Projekt wählen —</option>
-        <option v-for="p in projects" :key="p.id" :value="p.id">{{ p.name }}</option>
-      </select>
+      <ProjectSelect v-model="form.project_id" :projects="projects" placeholder="— Projekt wählen —" required />
     </div>
     <div v-if="form.project_id">
       <label class="label">Aufgabe <span class="text-lo font-normal">(optional)</span></label>
@@ -45,6 +42,7 @@
 import { ref, computed, watch } from 'vue'
 import { api } from '../api/index.js'
 import MarkdownTextarea from './MarkdownTextarea.vue'
+import ProjectSelect from './ProjectSelect.vue'
 
 const props = defineProps({ projects: Array, entry: Object, loading: Boolean })
 const emit  = defineEmits(['submit', 'cancel'])

--- a/src/views/RolesView.vue
+++ b/src/views/RolesView.vue
@@ -55,26 +55,6 @@
         </table>
       </div>
     </section>
-
-    <!-- Projektberechtigungen -->
-    <section class="space-y-4 border-t border-groove pt-8">
-      <h2 class="text-lg font-semibold text-hi">Projektberechtigungen</h2>
-
-      <div class="card flex items-end gap-3">
-        <div class="flex-1 min-w-[15rem]">
-          <label class="label">Projekt auswählen</label>
-          <select v-model="selectedProjectId" class="input text-sm py-2">
-            <option :value="null">— Projekt wählen —</option>
-            <option v-for="p in projectsStore.list" :key="p.id" :value="p.id">{{ p.name }}</option>
-          </select>
-        </div>
-      </div>
-
-      <ProjectPermissionsPanel
-        v-if="selectedProjectId"
-        :project-id="selectedProjectId"
-        :users="lernende" />
-    </section>
   </div>
 </template>
 
@@ -82,9 +62,6 @@
 import { ref, computed, onMounted } from 'vue'
 import { useToast } from '../composables/useToast.js'
 import { api } from '../api/index.js'
-import { useProjectsStore } from '../stores/projects.js'
-import { useUsersStore } from '../stores/users.js'
-import ProjectPermissionsPanel from '../components/ProjectPermissionsPanel.vue'
 
 const ROLE_LABELS = {
   leiter:    'Leiter',
@@ -105,19 +82,12 @@ const GROUP_LABELS = {
   werkstatt:    'Werkstatt',
 }
 
-const projectsStore = useProjectsStore()
-const usersStore    = useUsersStore()
 const { toastError } = useToast()
 
-const loading          = ref(true)
-const roles            = ref([])
-const permissions      = ref([])
-const saving           = ref({})
-const selectedProjectId = ref(null)
-
-const lernende = computed(() =>
-  usersStore.list.filter(u => u.role === 'lernender' && u.active)
-)
+const loading     = ref(true)
+const roles       = ref([])
+const permissions = ref([])
+const saving      = ref({})
 
 const groups = computed(() => {
   const map = {}
@@ -133,11 +103,7 @@ const groups = computed(() => {
 })
 
 onMounted(async () => {
-  const [data] = await Promise.all([
-    api.getRoles(),
-    projectsStore.fetchAll(),
-    usersStore.list.length ? Promise.resolve() : usersStore.fetchAll(),
-  ])
+  const data = await api.getRoles()
   roles.value = data.roles
   permissions.value = data.permissions
   roles.value.forEach(r => (saving.value[r] = false))

--- a/src/views/TimeEntryView.vue
+++ b/src/views/TimeEntryView.vue
@@ -22,10 +22,7 @@
       </div>
       <div>
         <label class="label">Projekt</label>
-        <select v-model="filter.project_id" class="input w-48">
-          <option value="">Alle</option>
-          <option v-for="p in projects.list" :key="p.id" :value="p.id">{{ p.name }}</option>
-        </select>
+        <ProjectSelect v-model="filter.project_id" :projects="projects.list" placeholder="Alle" class="w-48" />
       </div>
     </div>
 
@@ -121,6 +118,7 @@ import ConfirmButton from '../components/ConfirmButton.vue'
 import Modal from '../components/Modal.vue'
 import TimeEntryForm from '../components/TimeEntryForm.vue'
 import PeriodSelector from '../components/PeriodSelector.vue'
+import ProjectSelect from '../components/ProjectSelect.vue'
 
 const route      = useRoute()
 const auth       = useAuthStore()


### PR DESCRIPTION
## Summary
- New `ProjectSelect` component groups projects into "Aktiv"/"Geplant" optgroups and hides `pausiert`/`abgeschlossen` projects.
- Replaced the plain project `<select>` in the time entry filter (TimeEntryView) and the time entry form (TimeEntryForm) with `ProjectSelect`.
- Removed the "Projektberechtigungen" section from RolesView — project permissions are already managed on the project detail page via `ProjectPermissionsPanel`.

## Test plan
- [ ] On the Zeiterfassung page, verify the project filter shows only Aktiv/Geplant projects grouped under headings.
- [ ] Open "Eintragen" modal and verify the project select is grouped the same way.
- [ ] Verify Berechtigungen page no longer shows the project permissions section, and project permissions still work from a project's detail page.