### PR TITLE
Add per-sprint capacity and Werkstatt usage display (#87)

### DIFF
--- a/src/components/SprintPanel.vue
+++ b/src/components/SprintPanel.vue
@@ -91,6 +91,10 @@
           </div>
         </div>
         <div>
+          <label class="label">Sprintgröße pro Lernende (Min.)</label>
+          <input v-model.number="form.capacity_min" type="number" min="0" step="15" class="input" />
+        </div>
+        <div>
           <MarkdownTextarea label="Sprint-Ziel" v-model="form.goal" :rows="2" placeholder="Was soll dieser Sprint erreichen?" />
         </div>
         <div class="flex gap-2 justify-end pt-2">
@@ -118,7 +122,7 @@ const auth      = useAuthStore()
 const showModal = ref(false)
 const editing   = ref(null)
 const expanded  = ref(false)
-const form      = ref({ name: '', start_date: '', end_date: '', goal: '' })
+const form      = ref({ name: '', start_date: '', end_date: '', goal: '', capacity_min: 900 })
 
 const today = new Date().toISOString().slice(0, 10)
 
@@ -187,13 +191,13 @@ function openNew() {
     mon = mondayOfNextWeek()
   }
   const kw = isoWeekNumber(new Date(mon + 'T00:00:00'))
-  form.value = { name: `KW ${kw}`, start_date: mon, end_date: fridayOfWeek(mon), goal: '' }
+  form.value = { name: `KW ${kw}`, start_date: mon, end_date: fridayOfWeek(mon), goal: '', capacity_min: 900 }
   showModal.value = true
 }
 
 function openEdit(sprint) {
   editing.value = sprint
-  form.value = { name: sprint.name, start_date: sprint.start_date, end_date: sprint.end_date, goal: sprint.goal ?? '' }
+  form.value = { name: sprint.name, start_date: sprint.start_date, end_date: sprint.end_date, goal: sprint.goal ?? '', capacity_min: sprint.capacity_min ?? 900 }
   showModal.value = true
 }
 

--- a/src/views/WerkstattView.vue
+++ b/src/views/WerkstattView.vue
@@ -21,6 +21,7 @@
             <th class="text-center px-4 py-3 font-medium text-mid">Offen / In Arbeit</th>
             <th class="text-center px-4 py-3 font-medium text-mid">Review / Erledigt</th>
             <th class="text-center px-4 py-3 font-medium text-mid">Stunden</th>
+            <th class="text-center px-4 py-3 font-medium text-mid">Kapazität</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-groove">
@@ -65,6 +66,21 @@
             <td class="px-4 py-3 text-center">
               <span class="font-medium text-hi">{{ r.declared_hours }}</span>
               <span class="text-lo ml-0.5">h</span>
+            </td>
+
+            <!-- Capacity -->
+            <td class="px-4 py-3 text-center">
+              <span v-if="r.capacity_min === null" class="text-lo">–</span>
+              <div v-else class="inline-flex flex-col items-center gap-1 min-w-[5.5rem]">
+                <span class="text-xs" :class="r.declared_min > r.capacity_min ? 'text-red-600 dark:text-red-400 font-semibold' : 'text-mid'">
+                  {{ r.declared_min }} / {{ r.capacity_min }} min
+                </span>
+                <span class="w-full h-1.5 rounded-full bg-lift ring-1 ring-line overflow-hidden">
+                  <span class="block h-full rounded-full"
+                        :class="r.declared_min > r.capacity_min ? 'bg-red-500' : 'bg-brand-500'"
+                        :style="{ width: Math.min(100, (r.declared_min / r.capacity_min) * 100) + '%' }" />
+                </span>
+              </div>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Summary
- SprintPanel: editable "Sprintgröße pro Lernende (Min.)" field, defaulting to 900
- WerkstattView: new Kapazität column showing declared vs. capacity minutes per lernende, with a progress bar (turns red when over capacity)

Requires backend PR: sbw-neue-medien/abteilung-webit-api#64. Dashboard widget intentionally out of scope, tracked separately.

## Test plan
- [x] Verified in browser via `npm run debug` against local API
- [x] Created/edited a sprint with custom capacity, confirmed it persists
- [x] Confirmed Werkstatt overview shows correct declared/capacity minutes for current sprint and for explicit date ranges matching a sprint