### PR TITLE
feat: CSV-Export Zeiterfassung, Sprint-Hervorhebung, bump to 1.9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Vue 3 Single-Page Application für die Verwaltung der webIT-Abteilung.
 
-**Version:** 1.9.2
+**Version:** 1.9.8
 **Repo:** `sbw-neue-medien/abteilung-webit-dash`
 **Backend:** [`sbw-neue-medien/abteilung-webit-api`](https://github.com/sbw-neue-medien/abteilung-webit-api)
 
@@ -159,6 +159,39 @@ npm run build        # Produktions-Build nach dist/
 ---
 
 ## Changelog
+
+### 1.9.8
+- **CSV-Export für Zeiterfassung** (`TimeEntryView.vue`) — exportiert die aktuell gefilterten Einträge als Excel-kompatible CSV (Semikolon-getrennt, UTF-8-BOM); Dateiname enthält bei aktivem Lernpartner-Filter dessen Namen
+- **`ProjectCard`-Komponente** — Projekt- und Vorlagenkarten in `ProjectsView.vue` waren als zwei fast identische Markup-Blöcke dupliziert; jetzt eine gemeinsame Komponente mit `is-template`/`can-edit`-Props
+- **Aktueller Sprint im Filter hervorgehoben** (`ProjectDetailView.vue`) — der heute aktive Sprint erhält einen Ring-Indikator im Sprint-Filter, unabhängig von der aktuellen Auswahl; `currentSprintId` von einer Funktion zu einem reaktiven `computed` gemacht
+
+### 1.9.7
+- **Projekt-Team kontaktieren** — Leiter können mit einem Klick eine E-Mail an alle Projektmitglieder senden (vorausgefüllter Betreff und Anrede)
+- **Zeiterfassung: Sprint-Perioden-Selektor** — derselbe Perioden-Selektor wie in der Werkstatt-Ansicht: direkte Sprint-Navigation oder freier Datumsbereich
+- **Zeiterfassung: Projektlink** — der Projektname in der Zeiterfassungstabelle verlinkt direkt auf die Projektdetailansicht
+- **Zeiterfassung: Stabile Spaltenbreiten** — Spaltenbreiten ändern sich nicht mehr mit dem Inhalt der Einträge
+- **Zeiterfassung: Schnelleintrag** — neuer «+»-Button in der Kopfzeile für schnelle Neueingaben
+
+### 1.9.6
+- **Lead-Time-Ansicht** — Leiter und Coaches sehen die verbuchte Brutto-Arbeitszeit pro Lernpartner im gewählten Zeitraum als farbigen Fortschrittsbalken; Coaches sehen nur ihre zugeordneten Lernpartner
+- **Kanban-Navigation in der Kopfzeile** — Vor/Zurück-Pfeile in einer festen Kopfzeile direkt neben den Spalten-Labels, die beim Scrollen sichtbar bleiben
+- **Einklappbare Projektbeschreibung** — lange Beschreibungen in der Projektdetailansicht sind standardmässig eingeklappt
+
+### 1.9.5
+- **Mentor-Auswahl für Projekte** — Projekte können einem Coach direkt zugewiesen werden (api#55)
+- **Kanban Pfeil-Navigation mit Snap-Scroll** — ersetzt die Scrollbar durch Pfeil-Buttons mit Snap-Verhalten (#82)
+- **Kanban öffnet automatisch im aktuellen Sprint** (#84)
+- **Persistenter «Eigenprojekte»-Filter** — Auswahl wird in `localStorage` gespeichert (#85, #86)
+- **Zeiterfassung: horizontales Scrollen statt Abschneiden** der Tabelle (#89)
+- **Mehrspaltige Markdown-Darstellung** für breite Container
+- Diverse Layout-Fixes (Footer, TimeEntryForm)
+
+### 1.9.4
+- **Confirm-Button-Overflow-Fix** — Bestätigungs-Popup überlappte den Bildschirmrand bei Lösch-Buttons nahe der rechten Kante (#76)
+- **Todo-Priorität statt Dauer** — Todos verwenden jetzt eine 1–5-Priorität statt einer geplanten Dauer (#78)
+
+### 1.9.3
+- **Zoom-Modal für Aufgaben** — schreibgeschütztes Vergrösserungs-Modal für Kanban-Karten (#74)
 
 ### 1.9.2
 - **Bugfix: Aufgabe leer im Zeiterfassungs-Bearbeiten-Formular** — beim Öffnen eines Eintrags blieb das Aufgaben-Feld leer, weil der Projekt-Watcher noch nicht registriert war, als die sofortige Entry-Watch-Initialisierung das Projekt setzte; Reihenfolge der `watch`-Aufrufe getauscht

--- a/management_summary.md
+++ b/management_summary.md
@@ -2,7 +2,7 @@
 title: "webIT Abteilungs-Dashboard"
 subtitle: "Management Summary"
 date: "Juni 2026"
-version: "1.9.7"
+version: "1.9.8"
 lang: de
 geometry: margin=2.5cm
 fontsize: 11pt
@@ -11,7 +11,7 @@ sansfont: "DejaVu Sans"
 colorlinks: true
 ---
 
-# Stand der Anwendung — Version 1.9.7
+# Stand der Anwendung — Version 1.9.8
 
 ## Worum geht es?
 
@@ -83,8 +83,13 @@ Damit ist es möglich, einen Lernpartner als **Projektleiter** für ein bestimmt
 - **Zeiterfassung: Stabile Spaltenbreiten** — Die Spaltenbreiten in der Zeiterfassungstabelle ändern sich nicht mehr mit dem Inhalt der Einträge.
 - **Zeiterfassung: Schnelleintrag** — Neuer «+»-Button in der Kopfzeile der Zeiterfassung für schnelle Neueingaben.
 
+### Neu in Version 1.9.8
+
+- **CSV-Export für Zeiterfassung** — Einträge der aktuell gefilterten Ansicht lassen sich als CSV-Datei herunterladen (Excel-kompatibel); ist ein Lernpartner ausgewählt, erscheint dessen Name im Dateinamen
+- **Aktueller Sprint im Filter hervorgehoben** — In der Projektdetailansicht markiert ein farbiger Ring den Sprint, der heute aktiv ist, unabhängig davon, welcher Sprint gerade ausgewählt ist
+
 ## Aktueller Stand
 
-Die Anwendung ist produktiv im Einsatz. Version 1.9.7 wurde im Juni 2026 veröffentlicht.
+Die Anwendung ist produktiv im Einsatz. Version 1.9.8 wurde im Juni 2026 veröffentlicht.
 
 **Produktions-Hinweis:** Beim Deployment einer neuen Version müssen Datenbank-Migrationen manuell auf dem Plesk-Server eingespielt werden, bevor der Code aktiviert wird.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "webit-abteilung",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/public/management-summary.html
+++ b/public/management-summary.html
@@ -162,11 +162,11 @@
   <header>
     <div class="label">webIT Abteilung</div>
     <h1>Management Summary</h1>
-    <span class="version">1.9.7</span>
+    <span class="version">1.9.8</span>
   </header>
   <main>
-    <h1 id="stand-der-anwendung-version-1.9.7">Stand der Anwendung —
-    Version 1.9.7</h1>
+    <h1 id="stand-der-anwendung-version-1.9.8">Stand der Anwendung —
+    Version 1.9.8</h1>
     <h2 id="worum-geht-es">Worum geht es?</h2>
     <p>Das webIT Abteilungs-Dashboard ist eine interne Webanwendung zur
     Verwaltung der Abteilungsarbeit. Es ermöglicht Lernenden, Leitern
@@ -355,8 +355,19 @@
     «+»-Button in der Kopfzeile der Zeiterfassung für schnelle
     Neueingaben.</li>
     </ul>
+    <h3 id="neu-in-version-1.9.8">Neu in Version 1.9.8</h3>
+    <ul>
+    <li><strong>CSV-Export für Zeiterfassung</strong> — Einträge der
+    aktuell gefilterten Ansicht lassen sich als CSV-Datei herunterladen
+    (Excel-kompatibel); ist ein Lernpartner ausgewählt, erscheint dessen
+    Name im Dateinamen</li>
+    <li><strong>Aktueller Sprint im Filter hervorgehoben</strong> — In
+    der Projektdetailansicht markiert ein farbiger Ring den Sprint, der
+    heute aktiv ist, unabhängig davon, welcher Sprint gerade ausgewählt
+    ist</li>
+    </ul>
     <h2 id="aktueller-stand">Aktueller Stand</h2>
-    <p>Die Anwendung ist produktiv im Einsatz. Version 1.9.7 wurde im
+    <p>Die Anwendung ist produktiv im Einsatz. Version 1.9.8 wurde im
     Juni 2026 veröffentlicht.</p>
     <p><strong>Produktions-Hinweis:</strong> Beim Deployment einer neuen
     Version müssen Datenbank-Migrationen manuell auf dem Plesk-Server

--- a/src/views/TimeEntryView.vue
+++ b/src/views/TimeEntryView.vue
@@ -2,12 +2,20 @@
   <div class="max-w-7xl mx-auto px-4 py-8 space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-2xl font-bold text-hi">Zeiterfassung</h1>
-      <button v-if="auth.can('time_entries.create')" class="btn-primary" @click="openCreate">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-        </svg>
-        Eintragen
-      </button>
+      <div class="flex gap-2">
+        <button class="btn-secondary" :disabled="!entries.length" @click="exportCsv">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v12m0 0l-4-4m4 4l4-4M4 20h16" />
+          </svg>
+          CSV exportieren
+        </button>
+        <button v-if="auth.can('time_entries.create')" class="btn-primary" @click="openCreate">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Eintragen
+        </button>
+      </div>
     </div>
 
     <div class="card flex flex-wrap gap-4 items-end">
@@ -181,4 +189,38 @@ async function onPeriodChange({ from, to } = {}) {
 }
 function formatMin(min) { if (!min) return '0h'; const h = Math.floor(min / 60), m = min % 60; return m ? `${h}h ${m}min` : `${h}h` }
 function formatDate(d) { return new Date(d).toLocaleDateString('de-CH', { day: '2-digit', month: '2-digit', year: 'numeric' }) }
+
+function csvEscape(value) {
+  const s = String(value ?? '')
+  return /[;"\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+function exportCsv() {
+  const cols = ['Datum']
+  if (auth.can('time_entries.read_all')) cols.push('Person')
+  cols.push('Projekt', 'Aufgabe', 'Dauer (Min)', 'Tätigkeit')
+
+  const rows = entries.value.map(e => {
+    const row = [formatDate(e.date)]
+    if (auth.can('time_entries.read_all')) row.push(e.user_name ?? '')
+    row.push(e.project_name ?? '', e.task_title ?? '', e.duration_min ?? 0, e.description ?? '')
+    return row
+  })
+
+  const csv = [cols, ...rows].map(row => row.map(csvEscape).join(';')).join('\r\n')
+  const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `zeiterfassung${exportFilenameSuffix()}_${filter.value.from}_${filter.value.to}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function exportFilenameSuffix() {
+  if (!filter.value.user_id) return ''
+  const learner = learners.value.find(u => u.id === filter.value.user_id)
+  if (!learner) return ''
+  return `_${learner.name.trim().replace(/\s+/g, '_').replace(/[^\w\-]/g, '')}`
+}
 </script>


### PR DESCRIPTION
## Summary
- CSV export for the filtered Zeiterfassung (time entries) list — Excel-compatible, includes the selected Lernpartner's name in the filename when filtered
- Highlight the currently active sprint in the project detail sprint filter with a ring indicator, independent of selection
- Extracted duplicated project/template card markup in ProjectsView into a shared `ProjectCard` component
- Bumped package.json to 1.9.8 and backfilled the README changelog for 1.9.3–1.9.7, which had never been recorded despite those version bumps landing in main
- Regenerated `management_summary.md` / `public/management-summary.html` for 1.9.8

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify CSV download in browser
- [ ] Manually verify sprint ring indicator in project detail view