### PR TITLE
Quartalswechsel-Assistent for issue #119

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Vue 3 Single-Page Application für die Verwaltung der webIT-Abteilung.
 
-**Version:** 1.9.8
+**Version:** 1.9.9
 **Repo:** `sbw-neue-medien/abteilung-webit-dash`
 **Backend:** [`sbw-neue-medien/abteilung-webit-api`](https://github.com/sbw-neue-medien/abteilung-webit-api)
 
@@ -47,6 +47,7 @@ src/
 │   ├── ConfirmButton.vue
 │   ├── NotificationBell.vue
 │   ├── ProjectPermissionsPanel.vue
+│   ├── QuarterWizard.vue
 │   ├── SideBar.vue
 │   ├── SprintPanel.vue
 │   ├── StatusBadge.vue
@@ -83,6 +84,8 @@ src/
 │   ├── useDarkMode.js
 │   ├── useNavLinks.js
 │   └── useToast.js
+├── utils/        # Reine Hilfsfunktionen
+│   └── sprintDates.js
 └── router/       # Route-Definitionen
 ```
 
@@ -124,7 +127,8 @@ src/
 - **Passwort-Reset** — per E-Mail anfordern und setzen
 - **Avatar-Upload** — Profilbild pro Benutzer
 - **E-Mail-Benachrichtigungen** — bei Review-Aufgaben (Leiter), bei Projekterstellung (Leiter + Mitglieder), bei Aufgabenzuweisung (Assignee), bei Eigenprojekt-Erstellung (Leiter + zugewiesene Coaches)
-- **Lernpartner deaktivieren** — kein Login, aus Auswahllisten ausgeblendet, Eigenprojekte pausiert
+- **Lernpartner deaktivieren** — kein Login, aus Auswahllisten ausgeblendet, Eigenprojekte pausiert, offene Aufgaben verlieren ihre Zuweisung; bei Reaktivierung wird das Eigenprojekt wieder aktiviert
+- **Quartalswechsel-Assistent** (`/lernende`, Leiter) — geführter Dialog für den Quartalswechsel: neue Sprints in Serie anlegen, mehrere Lernpartner auswählen und deaktivieren/aktivieren, jeweils mit Bestätigung
 - **Werkstatt-Übersicht** — Projekte, Sprint-Tasks, Stunden pro Lernpartner
 - **Dark Mode** — System-/manuelles Umschalten
 - **Todos** — Checklisten pro Projekt in der linken Sidebar (sichtbar auf `/projekte/:id`)
@@ -159,6 +163,10 @@ npm run build        # Produktions-Build nach dist/
 ---
 
 ## Changelog
+
+### 1.9.9
+- **Quartalswechsel-Assistent** (`QuarterWizard.vue`, `LearnersView.vue`) — geführter 3-Schritte-Dialog für den Quartalswechsel: 1) Serienanlage von Sprints (Datumslogik aus `SprintPanel.vue` nach `utils/sprintDates.js` extrahiert), 2) Lernpartner deaktivieren, 3) Lernpartner (re-)aktivieren; jede Aktion läuft über die bestehende `users.toggleActive()`-Action (#119)
+- **`LearnerCard.vue`** — Aktiv/Inaktiv-Checkbox durch `ConfirmButton` ersetzt (konsistent mit den übrigen Inline-Bestätigungen); Deaktivieren zeigt jetzt eine Warnung zu Eigenprojekt-Pause und Aufgaben-Entzug
 
 ### 1.9.8
 - **CSV-Export für Zeiterfassung** (`TimeEntryView.vue`) — exportiert die aktuell gefilterten Einträge als Excel-kompatible CSV (Semikolon-getrennt, UTF-8-BOM); Dateiname enthält bei aktivem Lernpartner-Filter dessen Namen

--- a/management_summary.md
+++ b/management_summary.md
@@ -2,7 +2,7 @@
 title: "webIT Abteilungs-Dashboard"
 subtitle: "Management Summary"
 date: "Juni 2026"
-version: "1.9.8"
+version: "1.9.9"
 lang: de
 geometry: margin=2.5cm
 fontsize: 11pt
@@ -11,7 +11,7 @@ sansfont: "DejaVu Sans"
 colorlinks: true
 ---
 
-# Stand der Anwendung — Version 1.9.8
+# Stand der Anwendung — Version 1.9.9
 
 ## Worum geht es?
 
@@ -36,7 +36,8 @@ Das webIT Abteilungs-Dashboard ist eine interne Webanwendung zur Verwaltung der 
 - **Todo-Listen** — Einfache Checklisten pro Projekt mit geplantem und tatsächlichem Aufwand
 - **Eigenprojekte** — Persönliche Projekte einem Lernpartner zuordnen
 - **Werkstatt-Übersicht** — Tabellarische Übersicht pro Lernpartner: aktive Projekte, Sprint-Tasks, Stunden
-- **Benutzerverwaltung** — Konten anlegen, Passwörter zurücksetzen, Profilbilder hochladen, Lernpartner deaktivieren
+- **Benutzerverwaltung** — Konten anlegen, Passwörter zurücksetzen, Profilbilder hochladen, Lernpartner deaktivieren/reaktivieren
+- **Quartalswechsel-Assistent** — geführter Dialog, um am Ende eines Quartals in einem Durchgang neue Sprints anzulegen sowie ausscheidende/neue Lernpartner zu (de)aktivieren
 - **Coach-System** — Coaches werden Lernpartner zugewiesen und erhalten automatisch Lesezugriff
 
 ### Neu in Version 1.7.0: Granulares Berechtigungssystem
@@ -88,8 +89,18 @@ Damit ist es möglich, einen Lernpartner als **Projektleiter** für ein bestimmt
 - **CSV-Export für Zeiterfassung** — Einträge der aktuell gefilterten Ansicht lassen sich als CSV-Datei herunterladen (Excel-kompatibel); ist ein Lernpartner ausgewählt, erscheint dessen Name im Dateinamen
 - **Aktueller Sprint im Filter hervorgehoben** — In der Projektdetailansicht markiert ein farbiger Ring den Sprint, der heute aktiv ist, unabhängig davon, welcher Sprint gerade ausgewählt ist
 
+### Neu in Version 1.9.9: Quartalswechsel-Assistent
+
+Lernpartner arbeiten in der webIT-Abteilung in Quartalen von rund 12 Sprints. Bisher musste der Leiter beim Quartalswechsel jeden Sprint einzeln anlegen, jeden ausscheidenden Lernpartner einzeln deaktivieren und offene Aufgaben von Hand neu zuweisen. Ein neuer geführter Dialog («Quartalswechsel») auf der Lernpartner-Seite bündelt diese drei Schritte:
+
+1. **Sprints anlegen** — eine ganze Serie neuer Sprints (Standard: 12) wird automatisch im Anschluss an den letzten bestehenden Sprint vorgeschlagen und mit einem Klick erstellt
+2. **Lernpartner deaktivieren** — gezielte Auswahl ausscheidender Lernpartner; ihr Eigenprojekt wird automatisch pausiert und ihre offenen Aufgaben verlieren die Zuweisung, damit sie nicht weiter beim ausgeschiedenen Lernpartner aufscheinen
+3. **Lernpartner (re-)aktivieren** — neue oder zurückkehrende Lernpartner werden aktiviert, ihr Eigenprojekt wird dabei automatisch wieder freigegeben
+
+Da Deaktivieren/Aktivieren weiterhin einzeln pro Lernpartner mit Bestätigung erfolgt, bleibt der Wechsel bewusst ein manueller, kontrollierter Vorgang — nicht jeder Lernpartner verlässt die Abteilung am Quartalsende.
+
 ## Aktueller Stand
 
-Die Anwendung ist produktiv im Einsatz. Version 1.9.8 wurde im Juni 2026 veröffentlicht.
+Die Anwendung ist produktiv im Einsatz. Version 1.9.9 wurde im Juni 2026 veröffentlicht.
 
 **Produktions-Hinweis:** Beim Deployment einer neuen Version müssen Datenbank-Migrationen manuell auf dem Plesk-Server eingespielt werden, bevor der Code aktiviert wird.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "webit-abteilung",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/public/management-summary.html
+++ b/public/management-summary.html
@@ -162,11 +162,11 @@
   <header>
     <div class="label">webIT Abteilung</div>
     <h1>Management Summary</h1>
-    <span class="version">1.9.8</span>
+    <span class="version">1.9.9</span>
   </header>
   <main>
-    <h1 id="stand-der-anwendung-version-1.9.8">Stand der Anwendung —
-    Version 1.9.8</h1>
+    <h1 id="stand-der-anwendung-version-1.9.9">Stand der Anwendung —
+    Version 1.9.9</h1>
     <h2 id="worum-geht-es">Worum geht es?</h2>
     <p>Das webIT Abteilungs-Dashboard ist eine interne Webanwendung zur
     Verwaltung der Abteilungsarbeit. Es ermöglicht Lernenden, Leitern
@@ -226,7 +226,11 @@
     <li><strong>Werkstatt-Übersicht</strong> — Tabellarische Übersicht
     pro Lernpartner: aktive Projekte, Sprint-Tasks, Stunden</li>
     <li><strong>Benutzerverwaltung</strong> — Konten anlegen, Passwörter
-    zurücksetzen, Profilbilder hochladen, Lernpartner deaktivieren</li>
+    zurücksetzen, Profilbilder hochladen, Lernpartner
+    deaktivieren/reaktivieren</li>
+    <li><strong>Quartalswechsel-Assistent</strong> — geführter Dialog,
+    um am Ende eines Quartals in einem Durchgang neue Sprints anzulegen
+    sowie ausscheidende/neue Lernpartner zu (de)aktivieren</li>
     <li><strong>Coach-System</strong> — Coaches werden Lernpartner
     zugewiesen und erhalten automatisch Lesezugriff</li>
     </ul>
@@ -366,8 +370,32 @@
     heute aktiv ist, unabhängig davon, welcher Sprint gerade ausgewählt
     ist</li>
     </ul>
+    <h3 id="neu-in-version-1.9.9-quartalswechsel-assistent">Neu in
+    Version 1.9.9: Quartalswechsel-Assistent</h3>
+    <p>Lernpartner arbeiten in der webIT-Abteilung in Quartalen von rund
+    12 Sprints. Bisher musste der Leiter beim Quartalswechsel jeden
+    Sprint einzeln anlegen, jeden ausscheidenden Lernpartner einzeln
+    deaktivieren und offene Aufgaben von Hand neu zuweisen. Ein neuer
+    geführter Dialog («Quartalswechsel») auf der Lernpartner-Seite
+    bündelt diese drei Schritte:</p>
+    <ol type="1">
+    <li><strong>Sprints anlegen</strong> — eine ganze Serie neuer
+    Sprints (Standard: 12) wird automatisch im Anschluss an den letzten
+    bestehenden Sprint vorgeschlagen und mit einem Klick erstellt</li>
+    <li><strong>Lernpartner deaktivieren</strong> — gezielte Auswahl
+    ausscheidender Lernpartner; ihr Eigenprojekt wird automatisch
+    pausiert und ihre offenen Aufgaben verlieren die Zuweisung, damit
+    sie nicht weiter beim ausgeschiedenen Lernpartner aufscheinen</li>
+    <li><strong>Lernpartner (re-)aktivieren</strong> — neue oder
+    zurückkehrende Lernpartner werden aktiviert, ihr Eigenprojekt wird
+    dabei automatisch wieder freigegeben</li>
+    </ol>
+    <p>Da Deaktivieren/Aktivieren weiterhin einzeln pro Lernpartner mit
+    Bestätigung erfolgt, bleibt der Wechsel bewusst ein manueller,
+    kontrollierter Vorgang — nicht jeder Lernpartner verlässt die
+    Abteilung am Quartalsende.</p>
     <h2 id="aktueller-stand">Aktueller Stand</h2>
-    <p>Die Anwendung ist produktiv im Einsatz. Version 1.9.8 wurde im
+    <p>Die Anwendung ist produktiv im Einsatz. Version 1.9.9 wurde im
     Juni 2026 veröffentlicht.</p>
     <p><strong>Produktions-Hinweis:</strong> Beim Deployment einer neuen
     Version müssen Datenbank-Migrationen manuell auf dem Plesk-Server

--- a/src/components/LearnerCard.vue
+++ b/src/components/LearnerCard.vue
@@ -38,12 +38,14 @@
       <button v-if="u.active" class="btn btn-sm btn-secondary" @click="$emit('edit', u)">Bearbeiten</button>
       <button v-if="u.active" class="btn btn-sm btn-secondary" @click="$emit('editPermissions', u)" title="Berechtigungen anpassen">Berechtigungen</button>
       <ConfirmButton v-if="u.active" class="btn btn-sm btn-danger" :label="`«${u.name}» wirklich löschen?`" @confirm="$emit('remove', u)">Löschen</ConfirmButton>
-      <label class="flex items-center gap-1.5 text-sm text-mid cursor-pointer ml-auto select-none">
-        <input type="checkbox" :checked="!!u.active"
-               class="rounded border-line text-brand-600"
-               @change="onChange($event)" />
+      <ConfirmButton v-if="u.active" class="btn btn-sm btn-secondary ml-auto"
+                     :label="`«${u.name}» deaktivieren? Eigenprojekt wird pausiert, offene Aufgaben verlieren ihre Zuweisung.`"
+                     @confirm="$emit('toggleActive', u, false)">
         Aktiv
-      </label>
+      </ConfirmButton>
+      <button v-else class="btn btn-sm btn-secondary ml-auto" @click="$emit('toggleActive', u, true)">
+        Inaktiv
+      </button>
     </div>
   </div>
 </template>
@@ -52,17 +54,9 @@
 import UserAvatar from './UserAvatar.vue'
 import ConfirmButton from './ConfirmButton.vue'
 
-const props = defineProps({
+defineProps({
   u:    { type: Object, required: true },
   auth: { type: Object, required: true },
 })
-const emit = defineEmits(['triggerUpload', 'removeAvatar', 'sendReset', 'edit', 'editPermissions', 'remove', 'toggleActive'])
-
-function onChange(e) {
-  const checked = e.target.checked
-  // Revert the native DOM state immediately: if the parent doesn't confirm
-  // (or the request fails), Vue won't re-patch :checked since u.active is unchanged.
-  e.target.checked = !!props.u.active
-  emit('toggleActive', props.u, checked)
-}
+defineEmits(['triggerUpload', 'removeAvatar', 'sendReset', 'edit', 'editPermissions', 'remove', 'toggleActive'])
 </script>

--- a/src/components/LearnerCard.vue
+++ b/src/components/LearnerCard.vue
@@ -41,7 +41,7 @@
       <label class="flex items-center gap-1.5 text-sm text-mid cursor-pointer ml-auto select-none">
         <input type="checkbox" :checked="!!u.active"
                class="rounded border-line text-brand-600"
-               @change="$emit('toggleActive', u, $event.target.checked)" />
+               @change="onChange($event)" />
         Aktiv
       </label>
     </div>
@@ -52,9 +52,17 @@
 import UserAvatar from './UserAvatar.vue'
 import ConfirmButton from './ConfirmButton.vue'
 
-defineProps({
+const props = defineProps({
   u:    { type: Object, required: true },
   auth: { type: Object, required: true },
 })
-defineEmits(['triggerUpload', 'removeAvatar', 'sendReset', 'edit', 'editPermissions', 'remove', 'toggleActive'])
+const emit = defineEmits(['triggerUpload', 'removeAvatar', 'sendReset', 'edit', 'editPermissions', 'remove', 'toggleActive'])
+
+function onChange(e) {
+  const checked = e.target.checked
+  // Revert the native DOM state immediately: if the parent doesn't confirm
+  // (or the request fails), Vue won't re-patch :checked since u.active is unchanged.
+  e.target.checked = !!props.u.active
+  emit('toggleActive', props.u, checked)
+}
 </script>

--- a/src/components/QuarterWizard.vue
+++ b/src/components/QuarterWizard.vue
@@ -38,9 +38,11 @@
           </label>
         </div>
         <div class="flex justify-end mt-3">
-          <button class="btn-secondary" :disabled="deactivating || !toDeactivate.length" @click="deactivateSelected">
+          <ConfirmButton
+            :label="`${toDeactivate.length} Lernpartner deaktivieren? Eigenprojekte werden pausiert, offene Aufgaben verlieren ihre Zuweisung.`"
+            class="btn-secondary" :disabled="deactivating || !toDeactivate.length" @confirm="deactivateSelected">
             {{ deactivating ? 'Wird deaktiviert…' : `${toDeactivate.length} deaktivieren` }}
-          </button>
+          </ConfirmButton>
         </div>
       </section>
 
@@ -75,6 +77,7 @@ import { useSprintsStore } from '../stores/sprints.js'
 import { useUsersStore } from '../stores/users.js'
 import { useToast } from '../composables/useToast.js'
 import Modal from './Modal.vue'
+import ConfirmButton from './ConfirmButton.vue'
 import { mondayOfNextWeek, fridayOfWeek, isoWeekNumber, mondayAfter } from '../utils/sprintDates.js'
 
 const props = defineProps({ modelValue: Boolean })

--- a/src/components/QuarterWizard.vue
+++ b/src/components/QuarterWizard.vue
@@ -1,0 +1,167 @@
+<template>
+  <Modal :model-value="modelValue" @update:model-value="close" title="Quartalswechsel" wide>
+    <div class="space-y-8">
+      <!-- Step 1: Sprints anlegen -->
+      <section>
+        <h4 class="font-semibold text-hi mb-2">1. Neue Sprints anlegen</h4>
+        <p class="text-xs text-lo mb-3">Lege die Sprints für das neue Quartal an. Sie schliessen direkt an den letzten bestehenden Sprint an.</p>
+        <div class="flex items-center gap-3 mb-3">
+          <label class="label mb-0">Anzahl Sprints</label>
+          <input v-model.number="sprintCount" type="number" min="1" max="20" class="input w-20" @change="regenerateSprints" />
+          <label class="label mb-0">Sprintgröße (Min.)</label>
+          <input v-model.number="defaultCapacity" type="number" min="0" step="15" class="input w-24" @change="applyCapacityToAll" />
+        </div>
+        <div class="space-y-2 max-h-64 overflow-y-auto">
+          <div v-for="(row, i) in sprintRows" :key="i" class="grid grid-cols-[1fr_auto_auto_auto] gap-2 items-end">
+            <input v-model="row.name" class="input" />
+            <input v-model="row.start_date" type="date" class="input" />
+            <input v-model="row.end_date" type="date" class="input" />
+            <input v-model.number="row.capacity_min" type="number" min="0" step="15" class="input w-24" />
+          </div>
+        </div>
+        <div class="flex justify-end mt-3">
+          <button class="btn-primary" :disabled="creatingSprints || !sprintRows.length" @click="createSprints">
+            {{ creatingSprints ? 'Wird erstellt…' : `${sprintRows.length} Sprint${sprintRows.length !== 1 ? 's' : ''} erstellen` }}
+          </button>
+        </div>
+      </section>
+
+      <!-- Step 2: Lernende deaktivieren -->
+      <section>
+        <h4 class="font-semibold text-hi mb-2">2. Lernende deaktivieren</h4>
+        <p class="text-xs text-lo mb-3">Eigenprojekte werden pausiert, offene Aufgaben dieser Lernpartner verlieren ihre Zuweisung.</p>
+        <div v-if="!activeLearners.length" class="text-lo italic text-sm">Keine aktiven Lernpartner.</div>
+        <div v-else class="space-y-1 max-h-48 overflow-y-auto">
+          <label v-for="u in activeLearners" :key="u.id" class="flex items-center gap-2 text-sm py-1">
+            <input type="checkbox" :value="u.id" v-model="toDeactivate" />
+            {{ u.name }}
+          </label>
+        </div>
+        <div class="flex justify-end mt-3">
+          <button class="btn-secondary" :disabled="deactivating || !toDeactivate.length" @click="deactivateSelected">
+            {{ deactivating ? 'Wird deaktiviert…' : `${toDeactivate.length} deaktivieren` }}
+          </button>
+        </div>
+      </section>
+
+      <!-- Step 3: Lernende aktivieren -->
+      <section>
+        <h4 class="font-semibold text-hi mb-2">3. Lernende (re-)aktivieren</h4>
+        <p class="text-xs text-lo mb-3">Eigenprojekte werden, falls pausiert, wieder aktiviert.</p>
+        <div v-if="!inactiveLearners.length" class="text-lo italic text-sm">Keine inaktiven Lernpartner.</div>
+        <div v-else class="space-y-1 max-h-48 overflow-y-auto">
+          <label v-for="u in inactiveLearners" :key="u.id" class="flex items-center gap-2 text-sm py-1">
+            <input type="checkbox" :value="u.id" v-model="toActivate" />
+            {{ u.name }}
+          </label>
+        </div>
+        <div class="flex justify-end mt-3">
+          <button class="btn-secondary" :disabled="activating || !toActivate.length" @click="activateSelected">
+            {{ activating ? 'Wird aktiviert…' : `${toActivate.length} aktivieren` }}
+          </button>
+        </div>
+      </section>
+
+      <div class="flex justify-end pt-2 border-t border-line">
+        <button class="btn-primary" @click="close">Fertig</button>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useSprintsStore } from '../stores/sprints.js'
+import { useUsersStore } from '../stores/users.js'
+import { useToast } from '../composables/useToast.js'
+import Modal from './Modal.vue'
+import { mondayOfNextWeek, fridayOfWeek, isoWeekNumber, mondayAfter } from '../utils/sprintDates.js'
+
+const props = defineProps({ modelValue: Boolean })
+const emit  = defineEmits(['update:modelValue'])
+
+const sprints = useSprintsStore()
+const users   = useUsersStore()
+const { toastSuccess, toastError } = useToast()
+
+const sprintCount     = ref(12)
+const defaultCapacity = ref(900)
+const sprintRows      = ref([])
+const creatingSprints = ref(false)
+
+const toDeactivate = ref([])
+const toActivate   = ref([])
+const deactivating = ref(false)
+const activating   = ref(false)
+
+const activeLearners   = computed(() => users.list.filter(u => u.role === 'lernender' && u.active))
+const inactiveLearners = computed(() => users.list.filter(u => u.role === 'lernender' && !u.active))
+
+watch(() => props.modelValue, (open) => {
+  if (open) {
+    toDeactivate.value = []
+    toActivate.value   = []
+    regenerateSprints()
+  }
+})
+
+function regenerateSprints() {
+  const sorted = [...sprints.list].sort((a, b) => a.start_date.localeCompare(b.start_date))
+  let mon = sorted.length ? mondayAfter(sorted[sorted.length - 1].end_date) : mondayOfNextWeek()
+  const rows = []
+  for (let i = 0; i < sprintCount.value; i++) {
+    const kw = isoWeekNumber(new Date(mon + 'T00:00:00'))
+    rows.push({ name: `KW ${kw}`, start_date: mon, end_date: fridayOfWeek(mon), capacity_min: defaultCapacity.value })
+    mon = mondayAfter(rows[rows.length - 1].end_date)
+  }
+  sprintRows.value = rows
+}
+
+function applyCapacityToAll() {
+  sprintRows.value.forEach(r => { r.capacity_min = defaultCapacity.value })
+}
+
+async function createSprints() {
+  creatingSprints.value = true
+  try {
+    await Promise.all(sprintRows.value.map(row => sprints.create(row)))
+    toastSuccess(`${sprintRows.value.length} Sprints erstellt.`)
+    regenerateSprints()
+  } catch (err) {
+    toastError(err.message)
+  } finally {
+    creatingSprints.value = false
+  }
+}
+
+async function deactivateSelected() {
+  deactivating.value = true
+  try {
+    const results = await Promise.all(toDeactivate.value.map(id => users.toggleActive(id, false)))
+    const unassigned = results.reduce((sum, r) => sum + (r?.unassigned_tasks ?? 0), 0)
+    toastSuccess(`${toDeactivate.value.length} deaktiviert${unassigned ? `, ${unassigned} Aufgabe(n) freigegeben.` : '.'}`)
+    toDeactivate.value = []
+  } catch (err) {
+    toastError(err.message)
+  } finally {
+    deactivating.value = false
+  }
+}
+
+async function activateSelected() {
+  activating.value = true
+  try {
+    await Promise.all(toActivate.value.map(id => users.toggleActive(id, true)))
+    toastSuccess(`${toActivate.value.length} aktiviert.`)
+    toActivate.value = []
+  } catch (err) {
+    toastError(err.message)
+  } finally {
+    activating.value = false
+  }
+}
+
+function close() {
+  emit('update:modelValue', false)
+}
+</script>

--- a/src/components/SprintPanel.vue
+++ b/src/components/SprintPanel.vue
@@ -114,6 +114,7 @@ import ConfirmButton from './ConfirmButton.vue'
 import Modal from './Modal.vue'
 import MarkdownRenderer from './MarkdownRenderer.vue'
 import MarkdownTextarea from './MarkdownTextarea.vue'
+import { mondayOfNextWeek, fridayOfWeek, isoWeekNumber, mondayAfter } from '../utils/sprintDates.js'
 
 const props = defineProps({ tasks: { type: Array, default: () => [] } })
 
@@ -183,10 +184,7 @@ function openNew() {
   let mon
   if (sorted.value.length) {
     const last = sorted.value[sorted.value.length - 1]
-    const d    = new Date(last.end_date + 'T00:00:00')
-    const day  = d.getDay()                          // 0=Sun … 6=Sat
-    d.setDate(d.getDate() + (day === 0 ? 1 : 8 - day)) // next Monday after end
-    mon = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    mon = mondayAfter(last.end_date)
   } else {
     mon = mondayOfNextWeek()
   }
@@ -209,24 +207,5 @@ async function save() {
 
 async function removeSprint(id) {
   await sprints.remove(id)
-}
-
-function mondayOfNextWeek() {
-  const d = new Date(), day = d.getDay()
-  d.setDate(d.getDate() + (day === 0 ? 1 : 8 - day))
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
-function isoWeekNumber(d) {
-  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
-  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7))
-  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
-  return Math.ceil((((date - yearStart) / 86400000) + 1) / 7)
-}
-
-function fridayOfWeek(mondayStr) {
-  const d = new Date(mondayStr + 'T00:00:00')
-  d.setDate(d.getDate() + 4)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 </script>

--- a/src/stores/users.js
+++ b/src/stores/users.js
@@ -29,9 +29,10 @@ export const useUsersStore = defineStore('users', () => {
   }
 
   async function toggleActive(id, active) {
-    await api.setUserActive(id, active)
+    const res = await api.setUserActive(id, active)
     const u = list.value.find(u => u.id === id)
     if (u) u.active = active ? 1 : 0
+    return res
   }
 
   return { list, loading, fetchAll, create, update, remove, toggleActive }

--- a/src/utils/sprintDates.js
+++ b/src/utils/sprintDates.js
@@ -1,0 +1,25 @@
+export function mondayOfNextWeek() {
+  const d = new Date(), day = d.getDay()
+  d.setDate(d.getDate() + (day === 0 ? 1 : 8 - day))
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function isoWeekNumber(d) {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7))
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
+  return Math.ceil((((date - yearStart) / 86400000) + 1) / 7)
+}
+
+export function fridayOfWeek(mondayStr) {
+  const d = new Date(mondayStr + 'T00:00:00')
+  d.setDate(d.getDate() + 4)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function mondayAfter(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00')
+  const day = d.getDay()
+  d.setDate(d.getDate() + (day === 0 ? 1 : 8 - day))
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -136,8 +136,19 @@ async function sendReset(u) {
 }
 
 async function handleToggleActive(u, active) {
-  await users.toggleActive(u.id, active)
-  toast(active ? `«${u.name}» wurde aktiviert.` : `«${u.name}» wurde deaktiviert.`)
+  if (!active) {
+    const ok = window.confirm(
+      `«${u.name}» deaktivieren?\n\nDas Eigenprojekt wird pausiert und alle offenen Aufgaben von ${u.name} werden ihm/ihr entzogen (Zuweisung entfernt).`
+    )
+    if (!ok) return
+  }
+  const res = await users.toggleActive(u.id, active)
+  if (active) {
+    toast(`«${u.name}» wurde aktiviert.`)
+  } else {
+    const n = res?.unassigned_tasks ?? 0
+    toast(`«${u.name}» wurde deaktiviert${n ? ` (${n} Aufgabe${n !== 1 ? 'n' : ''} freigegeben)` : ''}.`)
+  }
 }
 
 async function remove(u) {

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -2,12 +2,17 @@
   <div class="max-w-6xl mx-auto px-4 py-8 space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-2xl font-bold text-hi">Lernpartner</h1>
-      <button v-if="auth.can('users.create')" class="btn-primary" @click="openCreate">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-        </svg>
-        Lernpartner anlegen
-      </button>
+      <div class="flex items-center gap-2">
+        <button v-if="auth.isLeiter" class="btn-secondary" @click="showWizard = true">
+          Quartalswechsel
+        </button>
+        <button v-if="auth.can('users.create')" class="btn-primary" @click="openCreate">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+          </svg>
+          Lernpartner anlegen
+        </button>
+      </div>
     </div>
 
     <div v-if="users.loading" class="text-center py-12 text-lo italic">Laden…</div>
@@ -44,6 +49,8 @@
     <UserPermissionsModal v-if="permTarget" v-model="showPermModal"
       :user-id="permTarget.id" :user-name="permTarget.name" />
 
+    <QuarterWizard v-model="showWizard" />
+
     <Modal v-model="showModal" :title="editing ? 'Lernpartner bearbeiten' : 'Lernpartner anlegen'">
       <UserForm :user="editing" :loading="saving" @submit="save" @cancel="showModal = false" />
       <p v-if="!editing" class="mt-3 text-xs text-lo">
@@ -63,6 +70,7 @@ import Modal from '../components/Modal.vue'
 import UserForm from '../components/UserForm.vue'
 import LearnerCard from '../components/LearnerCard.vue'
 import UserPermissionsModal from '../components/UserPermissionsModal.vue'
+import QuarterWizard from '../components/QuarterWizard.vue'
 
 const auth              = useAuthStore()
 const users             = useUsersStore()
@@ -72,6 +80,7 @@ const editing   = ref(null)
 const saving    = ref(false)
 const permTarget    = ref(null)
 const showPermModal = ref(false)
+const showWizard    = ref(false)
 const fileInput = ref(null)
 const uploading = ref(null)
 

--- a/src/views/LearnersView.vue
+++ b/src/views/LearnersView.vue
@@ -136,12 +136,6 @@ async function sendReset(u) {
 }
 
 async function handleToggleActive(u, active) {
-  if (!active) {
-    const ok = window.confirm(
-      `«${u.name}» deaktivieren?\n\nDas Eigenprojekt wird pausiert und alle offenen Aufgaben von ${u.name} werden ihm/ihr entzogen (Zuweisung entfernt).`
-    )
-    if (!ok) return
-  }
   const res = await users.toggleActive(u.id, active)
   if (active) {
     toast(`«${u.name}» wurde aktiviert.`)


### PR DESCRIPTION
## Summary
- New `QuarterWizard.vue`: a guided 3-step dialog on `/lernende` (leiter-only) for the end-of-quarter changeover — batch-create the next ~12 sprints, deactivate outgoing learners, (re-)activate returning learners. Each step has its own confirm action so any step can be used independently.
- Extracted sprint date-rollover helpers from `SprintPanel.vue` into `utils/sprintDates.js`, shared by both components (pure refactor).
- `LearnerCard.vue`: replaced the Aktiv/Inaktiv checkbox with `ConfirmButton` (consistent with the rest of the app's inline-confirmation pattern) and added a warning about the Eigenprojekt-pause/task-unassign cascade before deactivating.
- Bumped to 1.9.9, updated README + management_summary.md (+ regenerated `public/management-summary.html` via pandoc).

Closes #119. Pairs with `abteilung-webit-api` PR #66, which adds the actual unassign/reactivate cascade this UI relies on.

## Test plan
- [x] `npm run build` clean
- [x] Manually exercised the cascade end-to-end against the dev DB (see API PR)
- [ ] Open the wizard on `/lernende` as leiter and walk through all three steps