### PR TITLE
fix: decode HTML entities in project card description preview

### DIFF
--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -50,7 +50,11 @@ const deleteLabel = computed(() =>
   `${props.isTemplate ? 'Vorlage' : 'Projekt'} «${props.project.name}» wirklich löschen?`
 )
 
+const HTML_ENTITIES = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'" }
+
 function markdownPreview(text) {
-  return marked.parse(text ?? '').replace(/<[^>]*>/g, '')
+  return marked.parse(text ?? '')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;|&lt;|&gt;|&quot;|&#39;/g, (entity) => HTML_ENTITIES[entity])
 }
 </script>


### PR DESCRIPTION
## Summary
- `ProjectCard.vue`'s blurb preview ran markdown through `marked.parse()` and stripped tags with a regex, but left HTML entities (e.g. `&quot;`) in the plain text
- Project descriptions containing `"` rendered as literal `&quot;` in the card
- Now decodes the common entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`) after stripping tags

Fixes #124

## Test plan
- [ ] Create/edit a project with a description containing `"`
- [ ] Confirm the project card preview shows `"` instead of `&quot;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)